### PR TITLE
Support custom absolute import prefixes

### DIFF
--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -43,6 +43,17 @@ module.exports = {
       },
     },
     {
+      files: ["absolute-prefix.js"],
+      rules: {
+        sort: [
+          "error",
+          {
+            absolutePrefixes: ["/", "@/"],
+          },
+        ],
+      },
+    },
+    {
       // Use these rules from eslint-plugin-import
       // (https://github.com/benmosher/eslint-plugin-import/) if you want hoist
       // imports to the top and add a blank line after them.

--- a/examples/absolute-prefix.js
+++ b/examples/absolute-prefix.js
@@ -1,0 +1,12 @@
+import Vue from "vue"
+import VueCurrencyFilter from "vue-currency-filter"
+// This will be treated as an absolute import because "@/" is added to absolutePrefixes
+import Icon from "@/components/icon.vue"
+// This will be treated as a global package because "#/" is not added to absolutePrefixes
+import foo from "#/foo"
+// This is a global package
+import storybook from "@storybook/react"
+import App from "./App.vue"
+import router from "./router"
+
+Vue.config.productionTip = false

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -51,6 +51,24 @@ import {
 
 `;
 
+exports[`examples absolute-prefix.js 1`] = `
+// This will be treated as a global package because "#/" is not added to absolutePrefixes
+import foo from "#/foo"
+// This is a global package
+import storybook from "@storybook/react"
+import Vue from "vue"
+import VueCurrencyFilter from "vue-currency-filter"
+
+// This will be treated as an absolute import because "@/" is added to absolutePrefixes
+import Icon from "@/components/icon.vue"
+
+import App from "./App.vue"
+import router from "./router"
+
+Vue.config.productionTip = false
+
+`;
+
 exports[`examples eslint-plugin-import.js 1`] = `
 // This file uses rules from eslint-plugin-import
 // (https://github.com/benmosher/eslint-plugin-import/) to hoist the imports to


### PR DESCRIPTION
Support custom absolute import prefixes. Fixes #4.

This is the initial approach. I don't particularly like passing context through the entire stack. If it were my project I would refactor rule's `create` to instantiate a new class instance where `this.options` would be parsed options.