### PR TITLE
Add a shareable ESLint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,22 +92,13 @@ npm install --save-dev eslint-plugin-simple-import-sort
 
 ## Usage
 
-Add `simple-import-sort` to the plugins section of your `.eslintrc`
-configuration file. You can omit the `eslint-plugin-` prefix:
+To add the `simple-import-sort` plugin and activate the
+`simple-import-sort/sort` rule in your `.eslintrc` configuration file,
+just extend the `simple-import-sort/sort` configuration:
 
 ```json
 {
-  "plugins": ["simple-import-sort"]
-}
-```
-
-Then add the import sort rule:
-
-```json
-{
-  "rules": {
-    "simple-import-sort/sort": "error"
-  }
+  "extends": ["plugin:simple-import-sort/sort"]
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,12 @@ module.exports = {
   rules: {
     sort,
   },
+  configs: {
+    sort: {
+      plugins: ["simple-import-sort"],
+      rules: {
+        "simple-import-sort/sort": "error",
+      },
+    },
+  },
 };


### PR DESCRIPTION
This makes activating the plugin a one-step process instead of a two-step process.

I maintain an [ESLint configuration tool](https://www.swansontec.com/eslint-config-standard-kit/) which supports this plugin as one of its options, and I'm trying to lower the output complexity as much as possible.