### PR TITLE
Ensure side-effect import sorting maintains order for Node v10

### DIFF
--- a/src/sort.js
+++ b/src/sort.js
@@ -776,7 +776,7 @@ function sortImportItems(items) {
   return items.slice().sort((itemA, itemB) =>
     // If both items are side effect imports, keep their original order.
     itemA.isSideEffectImport && itemB.isSideEffectImport
-      ? 0
+      ? itemA.index - itemB.index
       : // If one of the items is a side effect import, move it first.
       itemA.isSideEffectImport
       ? -1


### PR DESCRIPTION
Fixes https://github.com/lydell/eslint-plugin-simple-import-sort/issues/34 with the suggestion you mentioned in https://github.com/lydell/eslint-plugin-simple-import-sort/issues/34#issuecomment-575006433

I tested this with the following versions:
- v10.16.3 (previously failed, now succeeds)
- v11.15.0
- v12.13.1

Anything else I should be adding to this PR? Thanks again!