### PR TITLE
Add Support for Sorting Exports

### DIFF
--- a/src/sort.js
+++ b/src/sort.js
@@ -136,13 +136,13 @@ function maybeReportSorting(imports, context, outerGroups, messageId) {
   }
 }
 
-function printSortedItems(importItems, sourceCode, outerGroups) {
+function printSortedItems(items, sourceCode, outerGroups) {
   const itemGroups = outerGroups.map((groups) =>
     groups.map((regex) => ({ regex, items: [] }))
   );
   const rest = [];
 
-  for (const item of importItems) {
+  for (const item of items) {
     const { originalSource } = item.source;
     const source = item.isSideEffectImport
       ? `\0${originalSource}`
@@ -168,7 +168,7 @@ function printSortedItems(importItems, sourceCode, outerGroups) {
     .concat([[{ regex: /^/, items: rest }]])
     .map((groups) => groups.filter((group) => group.items.length > 0))
     .filter((groups) => groups.length > 0)
-    .map((groups) => groups.map((group) => sortImportItems(group.items)));
+    .map((groups) => groups.map((group) => sortItems(group.items)));
 
   const newline = guessNewline(sourceCode);
 
@@ -185,7 +185,7 @@ function printSortedItems(importItems, sourceCode, outerGroups) {
   // so we don’t accidentally comment stuff out.
   const flattened = flatMap(sortedItems, (groups) => [].concat(...groups));
   const lastSortedItem = flattened[flattened.length - 1];
-  const lastOriginalItem = importItems[importItems.length - 1];
+  const lastOriginalItem = items[items.length - 1];
   const nextToken = lastSortedItem.needsNewline
     ? sourceCode.getTokenAfter(lastOriginalItem.node, {
         includeComments: true,
@@ -809,7 +809,7 @@ function getTrailingSpaces(node, sourceCode) {
   return lines[0];
 }
 
-function sortImportItems(items) {
+function sortItems(items) {
   return items.slice().sort((itemA, itemB) =>
     // If both items are side effect imports, keep their original order.
     itemA.isSideEffectImport && itemB.isSideEffectImport

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1866,24 +1866,25 @@ const baseExportTests = (expect) => ({
     `,
     'export {b, a} from "x"',
 
-    // Opt-out.
-    // {
-    //   options: [{ sortExports: true }],
-    //   code: input`
-    //       |// eslint-disable-next-line
-    //       |export x2 from "b"
-    //       |export x1 from "a";
-    //   `,
-    //   output: (actual) => {
-    //     // eslint-disable-next-line no-console
-    //     console.warn("actual:", actual);
-    //     expect(actual).toMatchInlineSnapshot(`
-    //       |// eslint-disable-next-line
-    //       |export x2 from "b"
-    //       |export x1 from "a";
-    //     `);
-    //   },
-    // },
+    // Opt-out - does not sort line
+    {
+      options: [{ sortExports: true }],
+      code: input`
+          |// eslint-disable-next-line
+          |export { c } from "c"
+          |export { b } from "b"
+          |export { a } from "a"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |// eslint-disable-next-line
+          |export { c } from "c"
+          |export { a } from "a"
+          |export { b } from "b"
+        `);
+      },
+      errors: 1,
+    },
   ],
   invalid: [
     // Sorts by source alphabetically

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1879,11 +1879,10 @@ const baseExportTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |// eslint-disable-next-line
           |export { c } from "c"
-          |export { a } from "a"
           |export { b } from "b"
+          |export { a } from "a"
         `);
       },
-      errors: 1,
     },
   ],
   invalid: [

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -2015,6 +2015,74 @@ const baseExportTests = (expect) => ({
       },
       errors: 1,
     },
+
+    // Comments after export are moved with it (named exports)
+    {
+      options: [{ sortExports: true }],
+      code: input`
+          |export { b } from "b"; // b
+          |export { a } from "a"; /* a */
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export { a } from "a"; /* a */
+          |export { b } from "b"; // b
+        `);
+      },
+      errors: 1,
+    },
+
+    // Comments after export are moved with it (all exports)
+    {
+      options: [{ sortExports: true }],
+      code: input`
+          |export * from "b"; // b
+          |export * from "a"; /* a */
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export * from "a"; /* a */
+          |export * from "b"; // b
+        `);
+      },
+      errors: 1,
+    },
+
+    // Line comments before export are unchanged
+    {
+      options: [{ sortExports: true }],
+      code: input`
+          |// exports below
+          |export * from "b"; // b
+          |export * from "a"; /* a */
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |// exports below
+          |export * from "a"; /* a */
+          |export * from "b"; // b
+        `);
+      },
+      errors: 1,
+    },
+
+    // Block comments before export are unchanged
+    {
+      options: [{ sortExports: true }],
+      code: input`
+          |/* exports below */
+          |export * from "b"; // b
+          |export * from "a"; /* a */
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |/* exports below */
+          |export * from "a"; /* a */
+          |export * from "b"; // b
+        `);
+      },
+      errors: 1,
+    },
   ],
 });
 

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1991,6 +1991,30 @@ const baseExportTests = (expect) => ({
       },
       errors: 2,
     },
+
+    // Sorts specifiers by name.
+    {
+      options: [{ sortExports: true }],
+      code: `export { c, b, a } from "specifiers"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a,b, c } from "specifiers"`
+        );
+      },
+      errors: 1,
+    },
+
+    // Sorts specifiers by name then alias.
+    {
+      options: [{ sortExports: true }],
+      code: `export { c, a, a as z, a as y } from "specifiers"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a, a as y,a as z, c } from "specifiers"`
+        );
+      },
+      errors: 1,
+    },
   ],
 });
 


### PR DESCRIPTION
- Off by default (enable via rule config)
- Only sorts exports after all imports
- Piggybacks off the existing import rules, with a few tweaks to get them to work with both imports and exports
- Basic unit tests included. I don't see anyone using these rules for much more than index files.