### PR TITLE
Sort exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ import {
   // Then everything else, alphabetically:
   k,
   L, // Case insensitive.
-  m as anotherName, // Sorted by the original name “m”, not “anotherName”.
-  m as tie, // But do use the \`as\` name in case of a tie.
+  m as anotherName, // Sorted by the “external interface” name “m”, not “anotherName”.
+  m as tie, // But do use the file-local name in case of a tie.
   n,
 } from "./x";
 ```
@@ -314,12 +314,14 @@ Exported items are sorted even for exports _without_ `from` (even though the who
 export {
   k,
   L, // Case insensitive.
-  m as anotherName, // Sorted by the original name “m”, not “anotherName”.
-  m as tie, // But do use the \`as\` name in case of a tie.
+  anotherName as m, // Sorted by the “external interface” name “m”, not “anotherName”.
+  tie as m, // But do use the file-local name in case of a tie.
   n,
 };
-export type { A, B, C as Aa };
+export type { A, B, A as C };
 ```
+
+At first it might sound counter-intuitive that `a as b` is sorted by `a` for imports, but by `b` for exports. The reason for doing it this way is to pick the most “stable” name. In `import { a as b } from "./some-file.js"`, the `as b` part is there to avoid a name collision in the file without having to change `some-file.js`. In `export { b as a }`, the `b as` part is there to aviod a name collison in the file without having to change the exported interface of the file.
 
 ## Custom grouping
 

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ export { g } from ".";
 export { h } from "./constants";
 export { i } from "./styles";
 
-// Other exports – the plugin does not touch these, other than sorting inside
-// named exports inside braces.
+// Other exports – the plugin does not touch these, other than sorting named
+// exports inside braces.
 export var one = 1;
 export let two = 2;
 export const three = 3;

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ import {/* comment at start */ f, /* f */g/* g */ } from "wherever3";
 
 If you wonder what’s up with the strange whitespace – see [“The sorting autofix causes some odd whitespace!”][odd-whitespace]
 
-Speaking of whitespace – what about blank lines? Just like comments, it’s difficult to know where blank lines should go after sorting. This plugin went with a simple approach – all blank lines in chunks of imports/exports are removed, except in `/**/` comments and the blank lines added between the groups mentioned in [Sort order].
+Speaking of whitespace – what about blank lines? Just like comments, it’s difficult to know where blank lines should go after sorting. This plugin went with a simple approach – all blank lines in chunks of imports are removed, except in `/**/` comments and the blank lines added between the groups mentioned in [Sort order]. For exports, blank lines are handled similarly, with a two added rules. First, exports without `from` _always_ have a blank line betwwen them. Exports _with_ `from` are surrounded by blank lines if they are multline. (Comments belonging to the export can cause the export to be considered multiline.)
 
 (Since blank lines are removed, you might get slight incompatibilities with the [lines-around-comment] and [padding-line-between-statements] rules – I don’t use those myself, but I think there should be workarounds.)
 

--- a/examples/groups.custom.js
+++ b/examples/groups.custom.js
@@ -1,18 +1,23 @@
 import fs from "fs";
+export {readFile} from "fs";
 import assert from "assert";
 import react from "react";
 import Select from "react-select"
 import _ from "lodash"
 import {providers} from "./providers"
+export {providers} from "./providers"
 import tomorrow from "./time/tomorrow"
 import now from "./time/now"
 import {PRODUCT_NAMES} from "."
+export {PRODUCT_NAMES} from "."
 import {CATEGORIES} from "../"
 import {truncate, removeWhitespace} from "../../utils";
+export {truncate, removeWhitespace} from "../../utils";
 import cssGlobals from "../../css/globals"
 import styles from "./styles.scss";
 import circleStyles from "./circle.scss";
 import "./global.scss"
+export default 5;
 import {name} from "@company/config"
 import Button from "@ui/Button";
 import Label from "components/Label"
@@ -24,3 +29,4 @@ import Textarea from "@/ui/Textarea"
 import "./local-polyfill"
 import "polyfill-package"
 import "../../alert.css"
+export const answer = 42;

--- a/examples/groups.custom.js
+++ b/examples/groups.custom.js
@@ -1,23 +1,18 @@
 import fs from "fs";
-export {readFile} from "fs";
 import assert from "assert";
 import react from "react";
 import Select from "react-select"
 import _ from "lodash"
 import {providers} from "./providers"
-export {providers} from "./providers"
 import tomorrow from "./time/tomorrow"
 import now from "./time/now"
 import {PRODUCT_NAMES} from "."
-export {PRODUCT_NAMES} from "."
 import {CATEGORIES} from "../"
 import {truncate, removeWhitespace} from "../../utils";
-export {truncate, removeWhitespace} from "../../utils";
 import cssGlobals from "../../css/globals"
 import styles from "./styles.scss";
 import circleStyles from "./circle.scss";
 import "./global.scss"
-export default 5;
 import {name} from "@company/config"
 import Button from "@ui/Button";
 import Label from "components/Label"
@@ -29,4 +24,10 @@ import Textarea from "@/ui/Textarea"
 import "./local-polyfill"
 import "polyfill-package"
 import "../../alert.css"
+
+export {readFile} from "fs";
+export {providers} from "./providers"
+export {PRODUCT_NAMES} from "."
+export {truncate, removeWhitespace} from "../../utils";
+export default 5;
 export const answer = 42;

--- a/examples/readme-order-items.prettier.js
+++ b/examples/readme-order-items.prettier.js
@@ -1,0 +1,15 @@
+import {
+  // First, type imports (`export { type x, typeof y }` is a syntax error).
+  type x,
+  typeof y,
+  // Numbers are sorted by their numeric value:
+  img1,
+  img2,
+  img10,
+  // Then everything else, alphabetically:
+  k,
+  L, // Case insensitive.
+  m as anotherName, // Sorted by the original name “m”, not “anotherName”.
+  m as tie, // But do use the \`as\` name in case of a tie.
+  n,
+} from "./x";

--- a/examples/readme-order-items.prettier.js
+++ b/examples/readme-order-items.prettier.js
@@ -9,7 +9,16 @@ import {
   // Then everything else, alphabetically:
   k,
   L, // Case insensitive.
-  m as anotherName, // Sorted by the original name “m”, not “anotherName”.
-  m as tie, // But do use the \`as\` name in case of a tie.
+  m as anotherName, // Sorted by the “external interface” name “m”, not “anotherName”.
+  m as tie, // But do use the file-local name in case of a tie.
   n,
 } from "./x";
+
+export {
+  k,
+  L, // Case insensitive.
+  anotherName as m, // Sorted by the “external interface” name “m”, not “anotherName”.
+  tie as m, // But do use the file-local name in case of a tie.
+  n,
+};
+export type { A, B, A as C };

--- a/examples/readme-order-items.prettier.js
+++ b/examples/readme-order-items.prettier.js
@@ -15,14 +15,14 @@ import {
 } from "./x";
 
 export {
-  k,
-  L, // Case insensitive.
-  anotherName as m, // Sorted by the “external interface” name “m”, not “anotherName”.
-  tie as m, // But do use the file-local name in case of a tie.
-  n,
+  k_,
+  L_, // Case insensitive.
+  anotherName_ as m, // Sorted by the “external interface” name “m”, not “anotherName”.
+  // tie as m, // For exports there can’t be ties – all exports must be unique.
+  n_,
 };
 export type { A, B, A as C };
 
-var k, L, anotherName, tie, n;
+var k_, L_, anotherName_, n_;
 type A = 1;
 type B = 1;

--- a/examples/readme-order-items.prettier.js
+++ b/examples/readme-order-items.prettier.js
@@ -22,3 +22,7 @@ export {
   n,
 };
 export type { A, B, A as C };
+
+var k, L, anotherName, tie, n;
+type A = 1;
+type B = 1;

--- a/examples/readme-order.prettier.js
+++ b/examples/readme-order.prettier.js
@@ -40,8 +40,8 @@ export { g } from ".";
 export { h } from "./constants";
 export { i } from "./styles";
 
-// Other exports – the plugin does not touch these, other than sorting inside
-// named exports inside braces.
+// Other exports – the plugin does not touch these, other than sorting named
+// exports inside braces.
 export var one = 1;
 export let two = 2;
 export const three = 3;

--- a/examples/readme-order.prettier.js
+++ b/examples/readme-order.prettier.js
@@ -40,7 +40,8 @@ export { g } from ".";
 export { h } from "./constants";
 export { i } from "./styles";
 
-// Other exports. (These are not sorted internally.)
+// Other exports – the plugin does not touch these, other than sorting inside
+// named exports inside braces.
 export var one = 1;
 export let two = 2;
 export const three = 3;

--- a/examples/readme-order.prettier.js
+++ b/examples/readme-order.prettier.js
@@ -44,13 +44,13 @@ export { i } from "./styles";
 export var one = 1;
 export let two = 2;
 export const three = 3;
-export function f() {}
-export class C {}
-export type T = string;
-export { a, b as c };
+export function func() {}
+export class Class {}
+export type Type = string;
+export { named, other as renamed };
 export type { T, U as V };
 export default whatever;
 
-var a, b;
+var named, other;
 type T = 1;
 type U = 1;

--- a/examples/readme-order.prettier.js
+++ b/examples/readme-order.prettier.js
@@ -10,7 +10,7 @@ import fs from "fs";
 import b from "https://example.com/script.js";
 
 // Absolute imports and other imports.
-import Error from "@/components/error.vue"
+import Error from "@/components/error.vue";
 import c from "/";
 import d from "/home/user/foo";
 
@@ -23,19 +23,30 @@ import g from ".";
 import h from "./constants";
 import i from "./styles";
 
-// Regardless of group, imported items are sorted like this:
-import {
-  // First, type imports.
-  type x,
-  typeof y,
-  // Then everything else, alphabetically:
-  k,
-  L, // Case insensitive.
-  m as anotherName, // Sorted by the original name “m”, not “anotherName”.
-  m as tie, // But do use the `as` name in case of a tie.
-  n,
-  // Numbers are sorted by their numeric value:
-  img1,
-  img2,
-  img10,
-} from "./x";
+// Package re-exports.
+export * from "an-npm-package";
+export { readFile } from "fs";
+export * as ns from "https://example.com/script.js";
+
+// Absolute and other re-exports.
+export { Error } from "@/components/error.vue";
+export { c } from "/";
+export { d } from "/home/user/foo";
+
+// Relative re-exports.
+export { e } from "../..";
+export { f } from "../../Utils"; // Case insensitive.
+export { g } from ".";
+export { h } from "./constants";
+export { i } from "./styles";
+
+// Other exports. (These are not sorted internally.)
+export var one = 1;
+export let two = 2;
+export const three = 3;
+export function f() {}
+export class C {}
+export type T = string;
+export { a, b as c };
+export type { T, U as V };
+export default whatever;

--- a/examples/readme-order.prettier.js
+++ b/examples/readme-order.prettier.js
@@ -50,3 +50,7 @@ export type T = string;
 export { a, b as c };
 export type { T, U as V };
 export default whatever;
+
+var a, b;
+type T = 1;
+type U = 1;

--- a/src/sort.js
+++ b/src/sort.js
@@ -102,8 +102,7 @@ function maybeReportChunkSorting(chunk, context, outerGroups) {
 }
 
 function maybeReportExportSpecifierSorting(node, context) {
-  const sourceCode = context.getSourceCode();
-  const sorted = printWithSortedSpecifiers(node, sourceCode);
+  const sorted = printWithSortedSpecifiers(node, context.getSourceCode());
   const [start, end] = node.range;
   maybeReportSorting(context, sorted, start, end, "exports");
 }

--- a/src/sort.js
+++ b/src/sort.js
@@ -159,7 +159,6 @@ function printSortedImportsOrExports(items, sourceCode, outerGroups) {
 }
 
 function printSortedImportsOrExportsHelper(items, sourceCode, outerGroups) {
-  const areImports = isImport(items[0].node);
   const itemGroups = outerGroups.map((groups) =>
     groups.map((regex) => ({ regex, items: [] }))
   );
@@ -199,29 +198,13 @@ function printSortedImportsOrExportsHelper(items, sourceCode, outerGroups) {
     .map((groups) =>
       groups
         .map((groupItems) =>
-          areImports
-            ? groupItems.map((item) => item.code).join(newline)
-            : // If an export is multiline (comments also count), surround it with
-              // blank lines.
-              groupItems
-                .map((item, index) => {
-                  const previous =
-                    index === 0 ? undefined : groupItems[index - 1];
-                  const before =
-                    previous != null &&
-                    !hasNewline(previous.code) &&
-                    hasNewline(item.code)
-                      ? newline
-                      : "";
-                  const after =
-                    index === groupItems.length - 1
-                      ? ""
-                      : hasNewline(item.code)
-                      ? newline + newline
-                      : newline;
-                  return before + item.code + after;
-                })
-                .join("")
+          groupItems
+            .map((item, index) =>
+              index > 0 && item.wantsBlankLineAbove
+                ? newline + item.code
+                : item.code
+            )
+            .join(newline)
         )
         .join(newline)
     )
@@ -319,6 +302,7 @@ function getImportExportItems(passedChunk, sourceCode) {
       needsNewline:
         commentsAfter.length > 0 &&
         isLineComment(commentsAfter[commentsAfter.length - 1]),
+      wantsBlankLineAbove: !isImport(importOrExportNode) && hasNewline(before),
     };
   });
 }

--- a/src/sort.js
+++ b/src/sort.js
@@ -166,7 +166,6 @@ function printSortedImportsOrExportsHelper(items, sourceCode, outerGroups) {
   const rest = [];
 
   for (const item of items) {
-    // All exports reaching this point are guaranteed to have `.source`.
     const { originalSource } = item.source;
     const source = item.isSideEffectImport
       ? `\0${originalSource}`
@@ -981,11 +980,6 @@ function isNewline(node) {
 }
 
 function getSource(importOrExportNode) {
-  // Not all exports have a `from` part.
-  if (!importOrExportNode.source) {
-    return undefined;
-  }
-
   const source = importOrExportNode.source.value;
 
   return {

--- a/src/sort.js
+++ b/src/sort.js
@@ -411,7 +411,8 @@ function printWithSortedSpecifiers(importOrExportNode, sourceCode) {
   );
 
   // Exclude "ImportDefaultSpecifier" – the "def" in `import def, {a, b}`.
-  const specifiers = importOrExportNode.specifiers.filter(
+  // `export * from "a"` does not have `.specifiers`.
+  const specifiers = (importOrExportNode.specifiers || []).filter(
     (node) => isImportSpecifier(node) || isExportSpecifier(node)
   );
 

--- a/src/sort.js
+++ b/src/sort.js
@@ -1,15 +1,15 @@
 "use strict";
 
 const defaultGroups = [
-  // Side effect imports.
+  // Side effect imports. (Exports don’t have this concept.)
   ["^\\u0000"],
   // Packages.
   // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
   ["^@?\\w"],
-  // Absolute imports and other imports such as Vue-style `@/foo`.
+  // Absolute and other imports/exports such as Vue-style `@/foo`.
   // Anything that does not start with a dot.
   ["^[^.]"],
-  // Relative imports.
+  // Relative imports/exports.
   // Anything that starts with a dot.
   ["^\\."],
 ];

--- a/src/sort.js
+++ b/src/sort.js
@@ -51,7 +51,11 @@ module.exports = {
     );
     return {
       Program: (node) => {
-        for (const chunk of extractChunks(node)) {
+        const chunks = [
+          ...extractChunks(node, isImport),
+          ...extractChunks(isExportFrom),
+        ];
+        for (const chunk of chunks) {
           maybeReportChunkSorting(chunk, context, outerGroups);
         }
       },
@@ -67,12 +71,12 @@ module.exports = {
 // A “chunk” is a sequence of import OR export-from statements with only
 // comments and whitespace between. Exports interrupt a chunk of imports and
 // vice versa.
-function extractChunks(programNode) {
+function extractChunks(programNode, isPartOfChunk) {
   const chunks = [];
   let chunk = [];
 
   for (const item of programNode.body) {
-    if (isImport(item) || isExportFrom(item)) {
+    if (isPartOfChunk(item)) {
       chunk.push(item);
     } else if (chunk.length > 0) {
       chunks.push(chunk);

--- a/src/sort.js
+++ b/src/sort.js
@@ -159,7 +159,7 @@ function printSortedImportsOrExports(items, sourceCode, outerGroups) {
 }
 
 function printSortedImportsOrExportsHelper(items, sourceCode, outerGroups) {
-  const areImports = isImport(items[0]);
+  const areImports = isImport(items[0].node);
   const itemGroups = outerGroups.map((groups) =>
     groups.map((regex) => ({ regex, items: [] }))
   );

--- a/src/sort.js
+++ b/src/sort.js
@@ -53,7 +53,7 @@ module.exports = {
       Program: (node) => {
         const chunks = [
           ...extractChunks(node, isImport),
-          ...extractChunks(isExportFrom),
+          ...extractChunks(node, isExportFrom),
         ];
         for (const chunk of chunks) {
           maybeReportChunkSorting(chunk, context, outerGroups);

--- a/src/sort.js
+++ b/src/sort.js
@@ -218,6 +218,7 @@ function printSortedImportsOrExportsHelper(items, sourceCode, outerGroups) {
 // comments is the hard part.
 function getImportExportItems(passedChunk, sourceCode) {
   const chunk = handleLastSemicolon(passedChunk, sourceCode);
+
   return chunk.map((importOrExportNode, importOrExportIndex) => {
     const lastLine =
       importOrExportIndex === 0
@@ -254,6 +255,7 @@ function getImportExportItems(passedChunk, sourceCode) {
       commentsBefore,
       sourceCode
     );
+
     const after = printCommentsAfter(
       importOrExportNode,
       commentsAfter,
@@ -320,12 +322,10 @@ function getImportExportItems(passedChunk, sourceCode) {
 function handleLastSemicolon(chunk, sourceCode) {
   const lastIndex = chunk.length - 1;
   const lastImportOrExport = chunk[lastIndex];
-  const [nextToLastToken, lastToken] = sourceCode.getLastTokens(
-    lastImportOrExport,
-    {
-      count: 2,
-    }
-  );
+  const [
+    nextToLastToken,
+    lastToken,
+  ] = sourceCode.getLastTokens(lastImportOrExport, { count: 2 });
   const lastIsSemicolon = isPunctuator(lastToken, ";");
 
   if (!lastIsSemicolon) {
@@ -736,6 +736,7 @@ function removeBlankLines(whitespace) {
 function getAllTokens(node, sourceCode) {
   const tokens = sourceCode.getTokens(node);
   const lastTokenIndex = tokens.length - 1;
+
   return flatMap(tokens, (token, tokenIndex) => {
     const newToken = Object.assign({}, token, {
       code: sourceCode.getText(token),
@@ -964,7 +965,6 @@ function isNewline(node) {
 
 function getSource(importOrExportNode) {
   const source = importOrExportNode.source.value;
-
   return {
     source:
       // Due to "." sorting before "/" by default, relative imports are

--- a/src/sort.js
+++ b/src/sort.js
@@ -40,7 +40,9 @@ module.exports = {
         "https://github.com/lydell/eslint-plugin-simple-import-sort#sort-order",
     },
     messages: {
-      sort: "Run autofix to sort these imports!",
+      imports: "Run autofix to sort these imports!",
+      exports: "Run autofix to sort these exports!",
+      both: "Run autofix to sort these imports and exports!",
     },
   },
   create: (context) => {

--- a/src/sort.js
+++ b/src/sort.js
@@ -60,7 +60,7 @@ module.exports = {
         }
       },
       ExportNamedDeclaration: (node) => {
-        if (node.source == null) {
+        if (node.source == null && node.declaration == null) {
           maybeReportExportSpecifierSorting(node, context);
         }
       },

--- a/src/sort.js
+++ b/src/sort.js
@@ -95,33 +95,25 @@ function maybeReportChunkSorting(chunk, context, outerGroups) {
   const sourceCode = context.getSourceCode();
   const items = getImportExportItems(chunk, sourceCode);
   const sorted = printSortedImportsOrExports(items, sourceCode, outerGroups);
-
   const { start } = items[0];
   const { end } = items[items.length - 1];
-  const original = sourceCode.getText().slice(start, end);
-
-  if (original !== sorted) {
-    context.report({
-      messageId: isImport(chunk[0]) ? "imports" : "exports",
-      loc: {
-        start: sourceCode.getLocFromIndex(start),
-        end: sourceCode.getLocFromIndex(end),
-      },
-      fix: (fixer) => fixer.replaceTextRange([start, end], sorted),
-    });
-  }
+  const messageId = isImport(chunk[0]) ? "imports" : "exports";
+  maybeReportSorting(context, sorted, start, end, messageId);
 }
 
 function maybeReportExportSpecifierSorting(node, context) {
   const sourceCode = context.getSourceCode();
   const sorted = printWithSortedSpecifiers(node, sourceCode);
-
   const [start, end] = node.range;
-  const original = sourceCode.getText().slice(start, end);
+  maybeReportSorting(context, sorted, start, end, "exports");
+}
 
+function maybeReportSorting(context, sorted, start, end, messageId) {
+  const sourceCode = context.getSourceCode();
+  const original = sourceCode.getText().slice(start, end);
   if (original !== sorted) {
     context.report({
-      messageId: "exports",
+      messageId,
       loc: {
         start: sourceCode.getLocFromIndex(start),
         end: sourceCode.getLocFromIndex(end),

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -319,8 +319,8 @@ export { g } from ".";
 export { h } from "./constants";
 export { i } from "./styles";
 
-// Other exports – the plugin does not touch these, other than sorting inside
-// named exports inside braces.
+// Other exports – the plugin does not touch these, other than sorting named
+// exports inside braces.
 export var one = 1;
 export let two = 2;
 export const three = 3;

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -309,13 +309,11 @@ export * as ns from "https://example.com/script.js";
 
 // Absolute and other re-exports.
 export { Error } from "@/components/error.vue";
-
 export { c } from "/";
 export { d } from "/home/user/foo";
 
 // Relative re-exports.
 export { e } from "../..";
-
 export { f } from "../../Utils"; // Case insensitive.
 export { g } from ".";
 export { h } from "./constants";

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -99,6 +99,15 @@ import "../../alert.css"
 import circleStyles from "./circle.scss";
 import styles from "./styles.scss";
 
+export {readFile} from "fs";
+
+export {removeWhitespace,truncate} from "../../utils";
+
+export {providers} from "./providers"
+export {PRODUCT_NAMES} from "."
+export default 5;
+export const answer = 42;
+
 `;
 
 exports[`examples groups.no-blank-lines.js 1`] = `
@@ -154,6 +163,7 @@ separator();
 import "side-effects";
 
 import Other from "another";
+
 // eslint-disable-next-line no-duplicate-imports, import/no-duplicates
 import Thing from "side-effects";
 // The above two lines will still be sorted after autofixing! This can be
@@ -217,6 +227,7 @@ import def, { // start
   f, // f
   // end
 } from "s";
+
 import { /* start */ a, /*a*/ b /*b*/ } from "t";
 
 `;
@@ -226,8 +237,10 @@ exports[`examples readme-comments.js 1`] = `
 // a1
 /* a2
  */ import a /* a3 */ from "a"; /* a4 */ 
+
 // b1
 import b from "b"; // b2
+
 /* c1 */ import c from "c"; // c2
 /* not-a
 */ // comment after import chunk
@@ -245,11 +258,13 @@ import { // comment at start
 /* not-a
   */ // comment at end
 } from "wherever";
+
 import {
   d, /* d */   e,
 /* not-d
   */ // comment at end after trailing comma
 } from "wherever2";
+
 import {/* comment at start */ f, /* f */g/* g */ } from "wherever3";
 
 `;
@@ -333,17 +348,23 @@ function pluck<T, K extends keyof T>(o: T, names: K[]): T[K][] {
 exports[`examples vue.vue 1`] = `
 <script lang="ts">
   /* a */ import a from "a"; 
+
   // b
   import {
     b2,
 b3,
     b4  } from "b";
+
 import c from "c"
+
     // d
     import d from "d"
+
   import e from "e"
+
   // Comment for vue-property-decorator
   import { Component, Vue, Watch } from 'vue-property-decorator';
+
   import { Location } from 'vue-router';
   </script>
 

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -163,7 +163,6 @@ separator();
 import "side-effects";
 
 import Other from "another";
-
 // eslint-disable-next-line no-duplicate-imports, import/no-duplicates
 import Thing from "side-effects";
 // The above two lines will still be sorted after autofixing! This can be
@@ -227,7 +226,6 @@ import def, { // start
   f, // f
   // end
 } from "s";
-
 import { /* start */ a, /*a*/ b /*b*/ } from "t";
 
 `;
@@ -237,10 +235,8 @@ exports[`examples readme-comments.js 1`] = `
 // a1
 /* a2
  */ import a /* a3 */ from "a"; /* a4 */ 
-
 // b1
 import b from "b"; // b2
-
 /* c1 */ import c from "c"; // c2
 /* not-a
 */ // comment after import chunk
@@ -258,13 +254,11 @@ import { // comment at start
 /* not-a
   */ // comment at end
 } from "wherever";
-
 import {
   d, /* d */   e,
 /* not-d
   */ // comment at end after trailing comma
 } from "wherever2";
-
 import {/* comment at start */ f, /* f */g/* g */ } from "wherever3";
 
 `;
@@ -307,9 +301,46 @@ import typeof C from "../types";
 import g from ".";
 import h from "./constants";
 import i from "./styles";
-// Regardless of group, imported items are sorted like this:
+
+// Package re-exports.
+export * from "an-npm-package";
+export { readFile } from "fs";
+export * as ns from "https://example.com/script.js";
+
+// Absolute and other re-exports.
+export { Error } from "@/components/error.vue";
+
+export { c } from "/";
+export { d } from "/home/user/foo";
+
+// Relative re-exports.
+export { e } from "../..";
+
+export { f } from "../../Utils"; // Case insensitive.
+export { g } from ".";
+export { h } from "./constants";
+export { i } from "./styles";
+
+// Other exports. (These are not sorted internally.)
+export var one = 1;
+export let two = 2;
+export const three = 3;
+export function func() {}
+export class Class {}
+export type Type = string;
+export { named, other as renamed };
+export type { T, U as V };
+export default whatever;
+
+var named, other;
+type T = 1;
+type U = 1;
+
+`;
+
+exports[`examples readme-order-items.prettier.js 1`] = `
 import {
-  // First, type imports.
+  // First, type imports (\`export { type x, typeof y }\` is a syntax error).
   type x,
   typeof y,
   // Numbers are sorted by their numeric value:
@@ -319,10 +350,23 @@ import {
   // Then everything else, alphabetically:
   k,
   L, // Case insensitive.
-  m as anotherName, // Sorted by the original name “m”, not “anotherName”.
-  m as tie, // But do use the \`as\` name in case of a tie.
+  m as anotherName, // Sorted by the “external interface” name “m”, not “anotherName”.
+  m as tie, // But do use the file-local name in case of a tie.
   n,
 } from "./x";
+
+export {
+  k_,
+  L_, // Case insensitive.
+  anotherName_ as m, // Sorted by the “external interface” name “m”, not “anotherName”.
+  // tie as m, // For exports there can’t be ties – all exports must be unique.
+  n_,
+};
+export type { A, B, A as C };
+
+var k_, L_, anotherName_, n_;
+type A = 1;
+type B = 1;
 
 `;
 
@@ -348,23 +392,17 @@ function pluck<T, K extends keyof T>(o: T, names: K[]): T[K][] {
 exports[`examples vue.vue 1`] = `
 <script lang="ts">
   /* a */ import a from "a"; 
-
   // b
   import {
     b2,
 b3,
     b4  } from "b";
-
 import c from "c"
-
     // d
     import d from "d"
-
   import e from "e"
-
   // Comment for vue-property-decorator
   import { Component, Vue, Watch } from 'vue-property-decorator';
-
   import { Location } from 'vue-router';
   </script>
 

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -319,7 +319,8 @@ export { g } from ".";
 export { h } from "./constants";
 export { i } from "./styles";
 
-// Other exports. (These are not sorted internally.)
+// Other exports – the plugin does not touch these, other than sorting inside
+// named exports inside braces.
 export var one = 1;
 export let two = 2;
 export const three = 3;

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fs = require("fs");
 const path = require("path");
 
 const spawn = require("cross-spawn");
@@ -32,7 +33,10 @@ describe("examples", () => {
           fixableWarningCount: 0,
         });
         const code = name.includes("prettier")
-          ? prettier.format(item.output, { parser: "babel" })
+          ? prettier.format(
+              item.output || fs.readFileSync(item.filePath, "utf8"),
+              { parser: "babel" }
+            )
           : item.output;
         expect(code).toMatchSnapshot();
       });

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -638,8 +638,7 @@ const baseTests = (expect) => ({
           |  Ba,
           |  BA,
           |  bA,
-          |  x as d,
-          |  x as C,
+          |  x,
           |  img10,
           |  img2,
           |  img1,
@@ -896,6 +895,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var c, b, a
           |export {
           |  // c
           |  c,
@@ -906,6 +906,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var c, b, a
           |export {
           |  a,
           |  b, // b
@@ -965,6 +966,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var c, b, a
           |export {
           |  // c
           |  c,b, // b
@@ -974,6 +976,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var c, b, a
           |export {
           |  a,
           |b, // b
@@ -1060,6 +1063,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var c, a
           |export {
           |  c,
           |  a,
@@ -1069,6 +1073,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var c, a
           |export {
           |  a,
           |  c,
@@ -1131,6 +1136,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var c, a
           |export {
           |  /*c1*/ c, /*c2*/ /*a1
           |  */a, /*a2*/ /*
@@ -1141,6 +1147,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var c, a
           |export {
           |/*a1
           |  */a, /*a2*/ 
@@ -1193,6 +1200,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |  b,
           |  a /*
@@ -1201,6 +1209,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |  a,   b/*
           |  after */
@@ -1253,6 +1262,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |  b,
           |  a /*a*/
@@ -1262,6 +1272,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |  a, /*a*/
           |  b  /*
@@ -1307,6 +1318,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |  b,
           |  a /*
@@ -1314,6 +1326,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |  a,   b/*
           |  after */ }
@@ -1458,7 +1471,7 @@ const baseTests = (expect) => ({
           |var c, b, a, e, d;
         `);
       },
-      errors: 1,
+      errors: 2,
     },
 
     // No empty line after last specifier due to newline before comma.
@@ -1840,64 +1853,64 @@ const baseTests = (expect) => ({
     },
 
     // Several chunks.
-    // TODO: Make this a really good test case and fix it.
-    {
-      code: input`
-          |require("c");
-          |
-          |export {x3} from "a"
-          |import i1 from "b"
-          |import i2 from "a"
-          |export {x4} from "c"
-          |require("c");
-          |
-          |import i3 from "b"
-          |export default 5
-          |export const answer = 42
-          |import i4 from "a" // x4
-          |
-          |// c1
-          |require("c");
-          |import i5 from "b"
-          |// x6-1
-          |import i6 from "a" /* after
-          |*/
-          |
-          |require("c"); import i7 from "b"; import i8 from "a"; export {x9}; require("c")
-          |var x9
-      `,
-      output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`
-          |require("c");
-          |
-          |import x2 from "a"
-          |import x1 from "b"
-          |
-          |export {x3} from "a"
-          |export {x4} from "c"
-          |require("c");
-          |
-          |import x4 from "a" // x4
-          |import x3 from "b"
-          |
-          |export default 5
-          |export const answer = 42
-          |
-          |// c1
-          |require("c");
-          |// x6-1
-          |import x6 from "a" 
-          |import x5 from "b"/* after
-          |*/
-          |
-          |require("c"); import x8 from "a"; 
-          |import x7 from "b";
-          |export {x8}; require("c")
-          |var x8
-        `);
-      },
-      errors: 4,
-    },
+    // TODOx: Make this a really good test case and fix it.
+    // {
+    //   code: input`
+    //       |require("c");
+    //       |
+    //       |export {x3} from "a"
+    //       |import i1 from "b"
+    //       |import i2 from "a"
+    //       |export {x4} from "c"
+    //       |require("c");
+    //       |
+    //       |import i3 from "b"
+    //       |export default 5
+    //       |export const answer = 42
+    //       |import i4 from "a" // x4
+    //       |
+    //       |// c1
+    //       |require("c");
+    //       |import i5 from "b"
+    //       |// x6-1
+    //       |import i6 from "a" /* after
+    //       |*/
+    //       |
+    //       |require("c"); import i7 from "b"; import i8 from "a"; export {x9}; require("c")
+    //       |var x9
+    //   `,
+    //   output: (actual) => {
+    //     expect(actual).toMatchInlineSnapshot(`
+    //       |require("c");
+    //       |
+    //       |import x2 from "a"
+    //       |import x1 from "b"
+    //       |
+    //       |export {x3} from "a"
+    //       |export {x4} from "c"
+    //       |require("c");
+    //       |
+    //       |import x4 from "a" // x4
+    //       |import x3 from "b"
+    //       |
+    //       |export default 5
+    //       |export const answer = 42
+    //       |
+    //       |// c1
+    //       |require("c");
+    //       |// x6-1
+    //       |import x6 from "a"
+    //       |import x5 from "b"/* after
+    //       |*/
+    //       |
+    //       |require("c"); import x8 from "a";
+    //       |import x7 from "b";
+    //       |export {x8}; require("c")
+    //       |var x8
+    //     `);
+    //   },
+    //   errors: 4,
+    // },
 
     // Original order is preserved for duplicate imports/exports.
     {
@@ -2240,6 +2253,7 @@ const baseTests = (expect) => ({
     },
 
     // Test messageId, lines and columns.
+    // TODOx: Check through if lines/cols actually are reasonable here.
     {
       code: input`
           |// before
@@ -2290,7 +2304,7 @@ const baseTests = (expect) => ({
           line: 3,
           column: 11,
           endLine: 4,
-          endColumn: 26,
+          endColumn: 28,
         },
       ],
     },
@@ -2300,6 +2314,7 @@ const baseTests = (expect) => ({
           |/* also
           |before */ export /*middle*/ {b,a}; /* comment
           |after */ // after
+          |var b, a
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -2307,6 +2322,7 @@ const baseTests = (expect) => ({
           |/* also
           |before */ export /*middle*/ {a,b}; /* comment
           |after */ // after
+          |var b, a
         `);
       },
       errors: [
@@ -2315,7 +2331,7 @@ const baseTests = (expect) => ({
           line: 3,
           column: 11,
           endLine: 3,
-          endColumn: 34,
+          endColumn: 35,
         },
       ],
     },
@@ -2654,7 +2670,7 @@ const baseTests = (expect) => ({
           |
           |    b: 2
           |    }, a = 1
-          |export {options, a}
+          |export {options as options2, a as a2}
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -3371,6 +3387,7 @@ const baseTests = (expect) => ({
     {
       options: [{ groups: [["^\\w"], ["^\\."]] }],
       code: input`
+          |var e
           |export {c} from '';
           |export {e}
           |export {b} from '.';
@@ -3379,6 +3396,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var e
           |export {a} from 'a';
           |
           |export {b} from '.';

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1482,7 +1482,6 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var b, a
           |export {
           |  b/*b*/
           |  ,
@@ -1491,7 +1490,6 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var b, a
           |export {
           |  a,
           |  b/*b*/
@@ -1551,7 +1549,6 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var z, y, x, w, v, t, s
           |export {z, y,
           |  x,
           |
@@ -1565,7 +1562,6 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var z, y, x, w, v, t, s
           |export {    s,
           |t /*t*/, // t
           |    v
@@ -1628,7 +1624,6 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var b, a
           |export {
           |b,
           |a,
@@ -1636,7 +1631,6 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var b, a
           |export {
           |a,
           |b,
@@ -1685,7 +1679,6 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var b, a
           |export {
           |    b,
           |    a,
@@ -1693,7 +1686,6 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var b, a
           |export {
           |    a,
           |    b,
@@ -1742,7 +1734,6 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var b, a
           |export {
           |\tb,
           |\ta,
@@ -1750,7 +1741,6 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var b, a
           |export {
           |→a,
           |→b,
@@ -1804,7 +1794,6 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var b, a, c
           |export {
           | //
           |\tb,
@@ -1815,7 +1804,6 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var b, a, c
           |export {
           |  a,
           | //
@@ -1929,14 +1917,12 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var b, a1, a2
           |export {b} from "b"
           |export {a1} from "a"
           |export {a2} from "a"
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var b, a1, a2
           |export {a1} from "a"
           |export {a2} from "a"
           |export {b} from "b"
@@ -1963,14 +1949,12 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
-          |var b, a1, a2
           |export {b} from "b"
           |export {a2} from "a"
           |export {a1} from "a"
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |var b, a1, a2
           |export {a2} from "a"
           |export {a1} from "a"
           |export {b} from "b"

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -332,8 +332,10 @@ const baseTests = (expect) => ({
           |export {x3} from "c"
           |export {x4} from "d" ; 
           |export {x5} from "e"
+          |
           |export {x6} from "f"
           |;
+          |
           |export {x7} from "g";[].forEach()
         `);
       },
@@ -404,6 +406,7 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |export {x1} from "a"
           |;
+          |
           |export {x2} from "b"
         `);
       },
@@ -1361,6 +1364,7 @@ const baseTests = (expect) => ({
           |  /* b3 */ /* not-a
           |  */ // comment at end
           |} from "specifiers-lots-of-comments-multiline";
+          |
           |export {
           |  d, /* d */   e,
           |/* not-d
@@ -1391,18 +1395,18 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |export { // start
-          |/* a1
-          |  */ a, 
+          |  /* c1 */ c /* c2 */, // c3
           |  // b1
+          |
           |  b as /* b2 */ renamed
-          |  , /* b3 */ 
-          |  /* c1 */ c /* c2 */// c3
-          |/* not-a
+          |  , /* b3 */ /* a1
+          |  */ a /* not-a
           |  */ // comment at end
           |};
+          |
           |export {
-          |  d, /* d */   e,
-          |/* not-d
+          |  e,
+          |  d, /* d */ /* not-d
           |  */ // comment at end after trailing comma
           |};
           |var c, b, a, e, d;
@@ -2067,10 +2071,12 @@ const baseTests = (expect) => ({
           |/* also
           |before */ export {a} from "a" /*a*/ 
           |/* b */ export {b} from "b" // b
+          |
           |/* before
           |  c0 */ // before c1
           |  /* c0
           |*/ /*c1*/ /*c2*/export {c} from 'c' ; /*c3*/ 
+          |
           |// above d
           |  export {d} /*d1*/ from   "d" ; /* d2 */ /*
           |   x1 */ /* x2 */
@@ -2295,9 +2301,11 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |// a
           |export {a} from "a"
+          |
           |// b1
           |// b2
           |export {b} from "b"
+          |
           |export {c} from "c"
         `);
       },
@@ -2346,9 +2354,11 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |// a<CR>
           |export {a} from "a"<CR>
+          |<CR>
           |// b1<CR>
           |// b2<CR>
           |export {b} from "b"<CR>
+          |<CR>
           |export {c} from "c"<CR>
           |after();<CR>
         `);
@@ -2680,14 +2690,18 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |  /* a */ export {a} from "a"; 
+          |
           |  // b
           |  export {
           |    b2,
           |b3,
           |    b4  } from "b";
+          |
           |export {c} from "c"
+          |
           |    // d
           |    export {d} from "d"
+          |
           |  export {e} from "e"
         `);
       },
@@ -2747,14 +2761,18 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |      <CR>
           |  /* a */ export {a} from "a"; <CR>
+          |<CR>
           |  // b<CR>
           |  export {<CR>
           |    b2,<CR>
           |b3,<CR>
           |    b4  } from "b";<CR>
+          |<CR>
           |export {c} from "c"<CR>
+          |<CR>
           |    // d<CR>
           |    export {d} from "d"<CR>
+          |<CR>
           |  export {e} from "e"<CR>
           |
         `);
@@ -2804,9 +2822,11 @@ const baseTests = (expect) => ({
           |/* multiline
           |comment */  
           |export {a} from "a"    
+          |
           |export {b} from "b";    
           |export {c} from "c";  /* comment */  
           |export {d} from "d";  
+          |
           |/* multiline
           |comment 2 */ export {f} from "f";
           |
@@ -2995,7 +3015,6 @@ const baseTests = (expect) => ({
     // https://github.com/apollographql/apollo-client/blob/39942881567ff9825a0f17bbf114ec441590f8bb/src/core/index.ts#L1-L98
     {
       code: input`
-          |export {
           |/* Core */
           |
           |export {
@@ -3693,17 +3712,24 @@ const flowTests = {
           |// Accepts optional IntrospectionOptions.
           |// Asserts that a string is a valid GraphQL name
           |export { assertValidName, isValidNameError } from './assertValidName';
+          |
           |// Create a GraphQL language AST from a JavaScript value.
           |export { astFromValue } from './astFromValue';
+          |
           |export type { BuildSchemaOptions } from './buildASTSchema';
+          |
           |// Build a GraphQLSchema from GraphQL Schema language.
           |export { buildASTSchema, buildSchema } from './buildASTSchema';
+          |
           |// Build a GraphQLSchema from an introspection result.
           |export { buildClientSchema } from './buildClientSchema';
+          |
           |// Coerces a JavaScript value to a GraphQL type, or produces errors.
           |export { coerceInputValue } from './coerceInputValue';
+          |
           |// Concatenates multiple AST together.
           |export { concatAST } from './concatAST';
+          |
           |// Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
           |export {
           |  extendSchema,
@@ -3711,7 +3737,9 @@ const flowTests = {
           |  // syntax for specifying descriptions - will be removed in v16.
           |  getDescription,
           |} from './extendSchema';
+          |
           |export type { BreakingChange, DangerousChange } from './findBreakingChanges';
+          |
           |// Compares two GraphQLSchemas and detects breaking changes.
           |export {
           |  BreakingChangeType,
@@ -3719,8 +3747,10 @@ const flowTests = {
           |  findBreakingChanges,
           |  findDangerousChanges,
           |} from './findBreakingChanges';
+          |
           |// Report all deprecated usage within a GraphQL document.
           |export { findDeprecatedUsages } from './findDeprecatedUsages';
+          |
           |export type {
           |  IntrospectionDirective,
           |  IntrospectionEnumType,
@@ -3745,39 +3775,52 @@ const flowTests = {
           |  IntrospectionTypeRef,
           |  IntrospectionUnionType,
           |} from './getIntrospectionQuery';
+          |
           |export { getIntrospectionQuery } from './getIntrospectionQuery';
+          |
           |// Gets the target Operation from a Document.
           |export { getOperationAST } from './getOperationAST';
+          |
           |// Gets the Type for the target Operation AST.
           |export { getOperationRootType } from './getOperationRootType';
+          |
           |// Convert a GraphQLSchema to an IntrospectionQuery.
           |export { introspectionFromSchema } from './introspectionFromSchema';
+          |
           |// Sort a GraphQLSchema.
           |export { lexicographicSortSchema } from './lexicographicSortSchema';
+          |
           |// Print a GraphQLSchema to GraphQL Schema language.
           |export {
           |  printIntrospectionSchema,
           |  printSchema,
           |  printType,
           |} from './printSchema';
+          |
           |// Separates an AST into an AST per Operation.
           |export { separateOperations } from './separateOperations';
+          |
           |// Strips characters that are not significant to the validity or execution
           |// of a GraphQL document.
           |export { stripIgnoredCharacters } from './stripIgnoredCharacters';
+          |
           |// Comparators for types
           |export {
           |  doTypesOverlap,
           |  isEqualType,
           |  isTypeSubTypeOf,
           |} from './typeComparators';
+          |
           |// Create a GraphQLType from a GraphQL language AST.
           |export { typeFromAST } from './typeFromAST';
+          |
           |// A helper to use within recursive-descent visitors which need to be aware of
           |// the GraphQL type system.
           |export { TypeInfo, visitWithTypeInfo } from './TypeInfo';
+          |
           |// Create a JavaScript value from a GraphQL language AST with a type.
           |export { valueFromAST } from './valueFromAST';
+          |
           |// Create a JavaScript value from a GraphQL language AST without a type.
           |export { valueFromASTUntyped } from './valueFromASTUntyped';
         `);
@@ -3945,6 +3988,7 @@ const typescriptTests = {
           |  | "networkError"
           |  | "graphQLErrors"
           |  >;
+          |
           |// A QueryInfo object represents a single query managed by the
           |// QueryManager, which tracks all QueryInfo objects by queryId in its...
           |export class QueryInfo {

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -309,10 +309,8 @@ const baseTests = (expect) => ({
           |import x3 from "c"
           |import x4 from "d" ; 
           |import x5 from "e"
-          |
           |import x6 from "f"
           |;
-          |
           |import x7 from "g";[].forEach()
         `);
       },
@@ -392,7 +390,6 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |import x1 from "a"
           |;
-          |
           |import x2 from "b"
         `);
       },
@@ -683,8 +680,7 @@ const baseTests = (expect) => ({
           |  Ba,
           |  BA,
           |  bA,
-          |  x as d,
-          |  x as C,
+          |  x,
           |  img10,
           |  img2,
           |  img1,
@@ -704,12 +700,12 @@ const baseTests = (expect) => ({
           |  Bb,
           |  bB,
           |  bb,
+          |  x as C,
+          |  x as d,
           |  img1,
           |  img2,
           |  img10,
           |  img10_black,
-          |  x as C,
-          |  x as d,
           |}
         `);
       },
@@ -1385,7 +1381,6 @@ const baseTests = (expect) => ({
           |/* not-a
           |  */ // comment at end
           |} from "specifiers-lots-of-comments-multiline";
-          |
           |import {
           |  d, /* d */   e,
           |/* not-d
@@ -1454,18 +1449,17 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |export { // start
+          |/* a1
+          |  */ a, 
           |  /* c1 */ c /* c2 */, // c3
           |  // b1
-          |
           |  b as /* b2 */ renamed
-          |  , /* b3 */ /* a1
-          |  */ a /* not-a
+          |  /* b3 */ /* not-a
           |  */ // comment at end
           |};
-          |
           |export {
-          |  e,
-          |  d, /* d */ /* not-d
+          |  d, /* d */   e,
+          |/* not-d
           |  */ // comment at end after trailing comma
           |};
           |var c, b, a, e, d;
@@ -2111,12 +2105,10 @@ const baseTests = (expect) => ({
           |/* also
           |before */ import a from "a" /*a*/ 
           |/* b */ import b from "b" // b
-          |
           |/* before
           |  c0 */ // before c1
           |  /* c0
           |*/ /*c1*/ /*c2*/import c from 'c' ; /*c3*/ 
-          |
           |// above d
           |  import d /*d1*/ from   "d" ; /* d2 */ /*
           |   x1 */ /* x2 */
@@ -2352,11 +2344,9 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |// a
           |import a from "a"
-          |
           |// b1
           |// b2
           |import b from "b"
-          |
           |import c from "c"
         `);
       },
@@ -2405,11 +2395,9 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |// a<CR>
           |import a from "a"<CR>
-          |<CR>
           |// b1<CR>
           |// b2<CR>
           |import b from "b"<CR>
-          |<CR>
           |import c from "c"<CR>
           |after();<CR>
         `);
@@ -2674,14 +2662,13 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |export {a} from "a"
-          |
           |export const options = {
           |
           |    a: 1,
           |
           |    b: 2
-          |    }"specifiers-empty"
+          |    }, a = 1
+          |export {a as a2,options as options2}
         `);
       },
       errors: 1,
@@ -2739,18 +2726,14 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |  /* a */ import a from "a"; 
-          |
           |  // b
           |  import {
           |    b2,
           |b3,
           |    b4  } from "b";
-          |
           |import c from "c"
-          |
           |    // d
           |    import d from "d"
-          |
           |  import e from "e"
         `);
       },
@@ -2810,18 +2793,14 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |      <CR>
           |  /* a */ import a from "a"; <CR>
-          |<CR>
           |  // b<CR>
           |  import {<CR>
           |    b2,<CR>
           |b3,<CR>
           |    b4  } from "b";<CR>
-          |<CR>
           |import c from "c"<CR>
-          |<CR>
           |    // d<CR>
           |    import d from "d"<CR>
-          |<CR>
           |  import e from "e"<CR>
           |
         `);
@@ -2882,12 +2861,10 @@ const baseTests = (expect) => ({
           |/* multiline
           |comment */  
           |import a from "a"    
-          |
           |import b from "b";    
           |import c from "c";  /* comment */  
           |import d from "d";  
           |import e from "e"; 
-          |
           |/* multiline
           |comment 2 */ import f from "f";
         `);
@@ -3022,7 +2999,6 @@ const baseTests = (expect) => ({
           |import { connect } from 'react-redux';
           |
           |import agent from '../agent';
-          |
           |import {
           |  ADD_TAG,
           |  ARTICLE_SUBMITTED,
@@ -3031,7 +3007,6 @@ const baseTests = (expect) => ({
           |  REMOVE_TAG,
           |  UPDATE_FIELD_EDITOR
           |} from '../constants/actionTypes';
-          |
           |import ListErrors from './ListErrors';
         `);
       },
@@ -3397,14 +3372,13 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |var e
+          |export {c} from '';
+          |export {e}
           |export {a} from 'a';
           |
           |export {b} from '.';
           |
-          |export {c} from '';
           |export {d} from '@/a';
-          |
-          |export {e}
         `);
       },
       errors: 1,

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -3742,7 +3742,6 @@ const flowTests = {
           |import type { ObjMap } from '../jsutils/ObjMap';
           |import promiseForObject from '../jsutils/promiseForObject';
           |import promiseReduce from '../jsutils/promiseReduce';
-          |
           |import type {
           |  DocumentNode,
           |  FieldNode,
@@ -3752,9 +3751,7 @@ const flowTests = {
           |  OperationDefinitionNode,
           |  SelectionSetNode,
           |} from '../language/ast';
-          |
           |import { Kind } from '../language/kinds';
-          |
           |import type {
           |  GraphQLAbstractType,
           |  GraphQLField,
@@ -3766,7 +3763,6 @@ const flowTests = {
           |  GraphQLResolveInfo,
           |  ResponsePath,
           |} from '../type/definition';
-          |
           |import {
           |  isAbstractType,
           |  isLeafType,
@@ -3774,23 +3770,19 @@ const flowTests = {
           |  isNonNullType,
           |  isObjectType,
           |} from '../type/definition';
-          |
           |import {
           |  GraphQLIncludeDirective,
           |  GraphQLSkipDirective,
           |} from '../type/directives';
-          |
           |import {
           |  SchemaMetaFieldDef,
           |  TypeMetaFieldDef,
           |  TypeNameMetaFieldDef,
           |} from '../type/introspection';
-          |
           |import type { GraphQLSchema } from '../type/schema';
           |import { assertValidSchema } from '../type/validate';
           |import { getOperationRootType } from '../utilities/getOperationRootType';
           |import { typeFromAST } from '../utilities/typeFromAST';
-          |
           |import {
           |  getArgumentValues,
           |  getDirectiveValues,
@@ -4189,12 +4181,10 @@ const typescriptTests = {
           |import { isNonEmptyArray } from '../utilities/common/arrays';
           |import { graphQLResultHasError } from '../utilities/common/errorHandling';
           |import { ObservableSubscription } from '../utilities/observables/Observable';
-          |
           |import {
           |  isNetworkRequestInFlight,
           |  NetworkStatus,
           |} from './networkStatus';
-          |
           |import { ObservableQuery } from './ObservableQuery';
           |import { QueryListener } from './types';
           |import { WatchQueryOptions } from './watchQueryOptions';
@@ -4240,13 +4230,13 @@ const expect2 = (...args) => {
   return ret;
 };
 javascriptRuleTester.run("JavaScript", plugin.rules.sort, baseTests(expect));
-// flowRuleTester.run("Flow", plugin.rules.sort, baseTests(expect2));
-// typescriptRuleTester.run("TypeScript", plugin.rules.sort, baseTests(expect2));
+flowRuleTester.run("Flow", plugin.rules.sort, baseTests(expect2));
+typescriptRuleTester.run("TypeScript", plugin.rules.sort, baseTests(expect2));
 
-// flowRuleTester.run("Flow-specific", plugin.rules.sort, flowTests);
+flowRuleTester.run("Flow-specific", plugin.rules.sort, flowTests);
 
-// typescriptRuleTester.run(
-//   "TypeScript-specific",
-//   plugin.rules.sort,
-//   typescriptTests
-// );
+typescriptRuleTester.run(
+  "TypeScript-specific",
+  plugin.rules.sort,
+  typescriptTests
+);

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -3477,7 +3477,7 @@ const baseTests = (expect) => ({
       errors: 1,
     },
 
-    // Mix of imports and different kinds of exports
+    // Mix of imports and different kinds of exports.
     {
       code: input`
           |import x1 from 'b';

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -163,7 +163,6 @@ const baseTests = (expect) => ({
           |  a, // a
           |  b // b
           |} from "specifiers-comment-space"
-          |
           |export {
           |  c, // c
           |  d, // d
@@ -332,10 +331,8 @@ const baseTests = (expect) => ({
           |export {x3} from "c"
           |export {x4} from "d" ; 
           |export {x5} from "e"
-          |
           |export {x6} from "f"
           |;
-          |
           |export {x7} from "g";[].forEach()
         `);
       },
@@ -406,7 +403,6 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |export {x1} from "a"
           |;
-          |
           |export {x2} from "b"
         `);
       },
@@ -1418,7 +1414,6 @@ const baseTests = (expect) => ({
           |  /* b3 */ /* not-a
           |  */ // comment at end
           |} from "specifiers-lots-of-comments-multiline";
-          |
           |export {
           |  d, /* d */   e,
           |/* not-d
@@ -2350,7 +2345,6 @@ const baseTests = (expect) => ({
           |// b1
           |// b2
           |export {b} from "b"
-          |
           |export {c} from "c"
         `);
       },
@@ -2403,7 +2397,6 @@ const baseTests = (expect) => ({
           |// b1<CR>
           |// b2<CR>
           |export {b} from "b"<CR>
-          |<CR>
           |export {c} from "c"<CR>
           |after();<CR>
         `);
@@ -2740,12 +2733,10 @@ const baseTests = (expect) => ({
           |    b2,
           |b3,
           |    b4  } from "b";
-          |
           |export {c} from "c"
           |
           |    // d
           |    export {d} from "d"
-          |
           |  export {e} from "e"
         `);
       },
@@ -2811,12 +2802,10 @@ const baseTests = (expect) => ({
           |    b2,<CR>
           |b3,<CR>
           |    b4  } from "b";<CR>
-          |<CR>
           |export {c} from "c"<CR>
           |<CR>
           |    // d<CR>
           |    export {d} from "d"<CR>
-          |<CR>
           |  export {e} from "e"<CR>
           |
         `);
@@ -2866,7 +2855,6 @@ const baseTests = (expect) => ({
           |/* multiline
           |comment */  
           |export {a} from "a"    
-          |
           |export {b} from "b";    
           |export {c} from "c";  /* comment */  
           |export {d} from "d";  
@@ -3193,23 +3181,18 @@ const baseTests = (expect) => ({
           |
           |/* Cache */
           |export * from '../cache';
-          |
           |export {
           |  FragmentMatcher as LocalStateFragmentMatcher,
           |  Resolver,
           |} from '../core/LocalState';
-          |
           |export { NetworkStatus } from '../core/networkStatus';
-          |
           |export {
           |  ApolloCurrentQueryResult,
           |  FetchMoreOptions,
           |  ObservableQuery,
           |  UpdateQueryOptions,
           |} from '../core/ObservableQuery';
-          |
           |export * from '../core/types';
-          |
           |export {
           |  ErrorPolicy,
           |  FetchMoreQueryOptions,
@@ -3223,14 +3206,12 @@ const baseTests = (expect) => ({
           |  WatchQueryFetchPolicy,
           |  WatchQueryOptions,
           |} from '../core/watchQueryOptions';
-          |
           |export { ApolloError,isApolloError } from '../errors/ApolloError';
           |export { ApolloLink } from '../link/core/ApolloLink';
           |export { concat } from '../link/core/concat';
           |
           |/* Link */
           |export { empty } from '../link/core/empty';
-          |
           |export { execute } from '../link/core/execute';
           |export { from } from '../link/core/from';
           |export { split } from '../link/core/split';
@@ -3239,30 +3220,24 @@ const baseTests = (expect) => ({
           |export { createHttpLink } from '../link/http/createHttpLink';
           |export { createSignalIfSupported } from '../link/http/createSignalIfSupported';
           |export { HttpLink } from '../link/http/HttpLink';
-          |
           |export {
           |  parseAndCheckHttpResponse,
           |  ServerParseError
           |} from '../link/http/parseAndCheckHttpResponse';
-          |
           |export {
           |  fallbackHttpConfig,
           |  HttpOptions,
           |  selectHttpOptionsAndBody,
           |  UriFunction
           |} from '../link/http/selectHttpOptionsAndBody';
-          |
           |export { selectURI } from '../link/http/selectURI';
-          |
           |export {
           |  ClientParseError,
           |  serializeFetchParameter} from '../link/http/serializeFetchParameter';
-          |
           |export { fromError } from '../link/utils/fromError';
           |export { fromPromise } from '../link/utils/fromPromise';
           |export { ServerError, throwServerError } from '../link/utils/throwServerError';
           |export { toPromise } from '../link/utils/toPromise';
-          |
           |export {
           |  Observable,
           |  ObservableSubscription,
@@ -3923,7 +3898,6 @@ const flowTests = {
           |
           |// Create a GraphQL language AST from a JavaScript value.
           |export { astFromValue } from './astFromValue';
-          |
           |export type { BuildSchemaOptions } from './buildASTSchema';
           |
           |// Build a GraphQLSchema from GraphQL Schema language.
@@ -3945,7 +3919,6 @@ const flowTests = {
           |  // syntax for specifying descriptions - will be removed in v16.
           |  getDescription,
           |} from './extendSchema';
-          |
           |export type { BreakingChange, DangerousChange } from './findBreakingChanges';
           |
           |// Compares two GraphQLSchemas and detects breaking changes.
@@ -3958,7 +3931,6 @@ const flowTests = {
           |
           |// Report all deprecated usage within a GraphQL document.
           |export { findDeprecatedUsages } from './findDeprecatedUsages';
-          |
           |export type {
           |  IntrospectionDirective,
           |  IntrospectionEnumType,
@@ -3983,7 +3955,6 @@ const flowTests = {
           |  IntrospectionTypeRef,
           |  IntrospectionUnionType,
           |} from './getIntrospectionQuery';
-          |
           |export { getIntrospectionQuery } from './getIntrospectionQuery';
           |
           |// Gets the target Operation from a Document.

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -3282,6 +3282,42 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+
+    // Mix of imports and different kinds of exports
+    {
+      code: input`
+          |import x1 from 'b';
+          |export * as x2 from 'b'
+          |export {c,b, a as d } from 'a';
+          |export {c1,b1, a as d1 };
+          |
+          |export default function add(a, b) {
+          |  // adds a and b
+          |  return a + b;
+          |
+          |} /* TODO */ import x3 from "./a"
+          |export function useless(a, b) { a, b }
+          |export class C /*C*/ extends Parent {
+          |  constructor(value) {
+          |    this.value = value;
+          |  }
+          |}
+          |export var v1 = 1
+          |export let v2 = 2, v2_2 = 22
+          |export const v3 = 3
+          |export const { name1, name2: renamed } = someObject
+          |import x0 from "a"
+          |import "style.css";
+          |export/**/const v4 = // v4
+          |
+          |  4
+          |;[].forEach()
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot();
+      },
+      errors: 1,
+    },
   ],
 });
 

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -3016,30 +3016,48 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |export {
-          |  batchedUpdates as unstable_batchedUpdates,
+          |var
+          |  createPortal,
+          |  batchedUpdates,
+          |  flushSync,
+          |  Internals,
+          |  ReactVersion,
+          |  findDOMNode,
+          |  hydrate,
+          |  render,
+          |  unmountComponentAtNode,
+          |  createRoot,
           |  createBlockingRoot,
-          |  // enableCreateEventHandleAPI
-          |  createEventHandle as unstable_createEventHandle,
+          |  flushControlled,
+          |  scheduleHydration,
+          |  renderSubtreeIntoContainer,
+          |  unstable_createPortal,
+          |  createEventHandle
+          |;
+          |export {
+          |  Internals as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+          |  createBlockingRoot,
           |  createPortal,
           |  // exposeConcurrentModeAPIs
           |  createRoot,
           |  // Disabled behind disableLegacyReactDOMAPIs
           |  findDOMNode,
-          |  flushControlled as unstable_flushControlled,
           |  flushSync,
           |  hydrate,
-          |  Internals as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
-          |  ReactVersion as version,
           |  render,
+          |  unmountComponentAtNode,
+          |  batchedUpdates as unstable_batchedUpdates,
+          |  // enableCreateEventHandleAPI
+          |  createEventHandle as unstable_createEventHandle,
+          |  // Disabled behind disableUnstableCreatePortal
+          |  // Temporary alias since we already shipped React 16 RC with it.
+          |  // TODO: remove in React 18.
+          |  unstable_createPortal,
+          |  flushControlled as unstable_flushControlled,
           |  // Disabled behind disableUnstableRenderSubtreeIntoContainer
           |  renderSubtreeIntoContainer as unstable_renderSubtreeIntoContainer,
           |  scheduleHydration as unstable_scheduleHydration,
-          |  unmountComponentAtNode,
-          |  // Disabled behind disableUnstableCreatePortal
-          |  // Temporary alias since we already shipped React 16 RC with it.
-          |  // TODO: remove in React 17.
-          |  unstable_createPortal,
+          |  ReactVersion as version,
           |};
         `);
       },

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -3525,6 +3525,36 @@ const baseTests = (expect) => ({
       },
       errors: 3,
     },
+
+    // Blank line above comment above export – unless already one due to grouping.
+    {
+      code: input`
+          |export {} from 'a';
+          |export {} from 'b';
+          |// a
+          |export {} from './a';
+          |/*b*/export {} from './b';
+          |// c
+          |export {} from './c';
+          |
+          |export {} from './d';
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {} from 'a';
+          |export {} from 'b';
+          |
+          |// a
+          |export {} from './a';
+          |/*b*/export {} from './b';
+          |
+          |// c
+          |export {} from './c';
+          |export {} from './d';
+        `);
+      },
+      errors: 1,
+    },
   ],
 });
 

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -142,6 +142,7 @@ const baseTests = (expect) => ({
           |// eslint-disable-next-line
           |import x2 from "b"
           |import x1 from "a";
+          |// eslint-disable-next-line
           |export {x4} from "b"
           |export {x3} from "a";
     `,
@@ -162,6 +163,7 @@ const baseTests = (expect) => ({
           |  a, // a
           |  b // b
           |} from "specifiers-comment-space"
+          |
           |export {
           |  c, // c
           |  d, // d
@@ -267,7 +269,6 @@ const baseTests = (expect) => ({
         `);
       },
       errors: 1,
-      parserOptions: { ecmaVersion: 2018 },
     },
     {
       code: input`
@@ -289,7 +290,6 @@ const baseTests = (expect) => ({
         `);
       },
       errors: 1,
-      parserOptions: { ecmaVersion: 2018 },
     },
 
     // Semicolons edge cases.
@@ -623,6 +623,27 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var
+          |  B,
+          |  a,
+          |  A,
+          |  b,
+          |  B2,
+          |  bb,
+          |  BB,
+          |  bB,
+          |  Bb,
+          |  ab,
+          |  ba,
+          |  Ba,
+          |  BA,
+          |  bA,
+          |  x as d,
+          |  x as C,
+          |  img10,
+          |  img2,
+          |  img1,
+          |  img10_black
           |export {
           |  B,
           |  a,
@@ -648,6 +669,27 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var
+          |  B,
+          |  a,
+          |  A,
+          |  b,
+          |  B2,
+          |  bb,
+          |  BB,
+          |  bB,
+          |  Bb,
+          |  ab,
+          |  ba,
+          |  Ba,
+          |  BA,
+          |  bA,
+          |  x as d,
+          |  x as C,
+          |  img10,
+          |  img2,
+          |  img1,
+          |  img10_black
           |export {
           |  A,
           |  a,
@@ -1440,6 +1482,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |  b/*b*/
           |  ,
@@ -1448,6 +1491,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |  a,
           |  b/*b*/
@@ -1458,6 +1502,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |  b/*b*/
           |  ,
@@ -1466,6 +1511,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |  a,
           |  b/*b*/
@@ -1505,6 +1551,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var z, y, x, w, v, t, s
           |export {z, y,
           |  x,
           |
@@ -1518,6 +1565,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var z, y, x, w, v, t, s
           |export {    s,
           |t /*t*/, // t
           |    v
@@ -1532,6 +1580,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var z, y, x, w, v, t, s
           |export {z, y,
           |  x,
           |
@@ -1545,6 +1594,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var z, y, x, w, v, t, s
           |export {    s,
           |t /*t*/, // t
           |    v
@@ -1578,6 +1628,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |b,
           |a,
@@ -1585,6 +1636,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |a,
           |b,
@@ -1595,6 +1647,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |b,
           |a,
@@ -1602,6 +1655,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |a,
           |b,
@@ -1631,6 +1685,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |    b,
           |    a,
@@ -1638,6 +1693,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |    a,
           |    b,
@@ -1648,6 +1704,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |    b,
           |    a,
@@ -1655,6 +1712,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |    a,
           |    b,
@@ -1684,6 +1742,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |\tb,
           |\ta,
@@ -1691,6 +1750,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |→a,
           |→b,
@@ -1701,6 +1761,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a
           |export {
           |\tb,
           |\ta,
@@ -1708,6 +1769,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a
           |export {
           |→a,
           |→b,
@@ -1742,6 +1804,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a, c
           |export {
           | //
           |\tb,
@@ -1752,6 +1815,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a, c
           |export {
           |  a,
           | //
@@ -1764,6 +1828,7 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a, c
           |export {
           | //
           |\tb,
@@ -1774,6 +1839,7 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a, c
           |export {
           |  a,
           | //
@@ -1786,29 +1852,30 @@ const baseTests = (expect) => ({
     },
 
     // Several chunks.
+    // TODO: Make this a really good test case and fix it.
     {
       code: input`
           |require("c");
           |
           |export {x3} from "a"
-          |import x1 from "b"
-          |import x2 from "a"
+          |import i1 from "b"
+          |import i2 from "a"
           |export {x4} from "c"
           |require("c");
           |
-          |import x3 from "b"
+          |import i3 from "b"
           |export default 5
           |export const answer = 42
-          |import x4 from "a" // x4
+          |import i4 from "a" // x4
           |
           |// c1
           |require("c");
-          |import x5 from "b"
+          |import i5 from "b"
           |// x6-1
-          |import x6 from "a" /* after
+          |import i6 from "a" /* after
           |*/
           |
-          |require("c"); import x7 from "b"; import x8 from "a"; export {x9}; require("c")
+          |require("c"); import i7 from "b"; import i8 from "a"; export {x9}; require("c")
           |var x9
       `,
       output: (actual) => {
@@ -1862,12 +1929,14 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a1, a2
           |export {b} from "b"
           |export {a1} from "a"
           |export {a2} from "a"
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a1, a2
           |export {a1} from "a"
           |export {a2} from "a"
           |export {b} from "b"
@@ -1894,12 +1963,14 @@ const baseTests = (expect) => ({
     },
     {
       code: input`
+          |var b, a1, a2
           |export {b} from "b"
           |export {a2} from "a"
           |export {a1} from "a"
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |var b, a1, a2
           |export {a2} from "a"
           |export {a1} from "a"
           |export {b} from "b"
@@ -3487,7 +3558,40 @@ const baseTests = (expect) => ({
           |var c1, b1, a;
       `,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot();
+        expect(actual).toMatchInlineSnapshot(`
+          |import x1 from 'b';
+          |export {b, c,a as d } from 'a';
+          |export * as x2 from 'b'
+          |export {b1, c1,a as d1 };
+          |
+          |export default function add(a, b) {
+          |  // adds a and b
+          |  return a + b;
+          |
+          |} /* TODO */ import x3 from "./a"
+          |export function useless(a, b) { a, b }
+          |export class C /*C*/ extends Parent {
+          |  constructor(value) {
+          |    this.value = value;
+          |  }
+          |}
+          |export var v1 = 1
+          |
+          |export let v2 = 2, v2_2 = 22
+          |
+          |
+          |  // Three!
+          |export const v3 = 3; /*middle*/ export const v3_2 = 33
+          |export const { name1, name2: renamed } = someObject
+          |import "style.css";
+          |
+          |import x0 from "a"
+          |export/**/const v4 = // v4
+          |
+          |  4
+          |;[].forEach()
+          |var c1, b1, a;
+        `);
       },
       errors: 3,
     },
@@ -4160,7 +4264,7 @@ const typescriptTests = {
 };
 
 const javascriptRuleTester = new RuleTester({
-  parserOptions: { ecmaVersion: 2015, sourceType: "module" },
+  parserOptions: { ecmaVersion: 2020, sourceType: "module" },
 });
 
 const flowRuleTester = new RuleTester({
@@ -4181,13 +4285,13 @@ const expect2 = (...args) => {
   return ret;
 };
 javascriptRuleTester.run("JavaScript", plugin.rules.sort, baseTests(expect));
-flowRuleTester.run("Flow", plugin.rules.sort, baseTests(expect2));
-typescriptRuleTester.run("TypeScript", plugin.rules.sort, baseTests(expect2));
+// flowRuleTester.run("Flow", plugin.rules.sort, baseTests(expect2));
+// typescriptRuleTester.run("TypeScript", plugin.rules.sort, baseTests(expect2));
 
-flowRuleTester.run("Flow-specific", plugin.rules.sort, flowTests);
+// flowRuleTester.run("Flow-specific", plugin.rules.sort, flowTests);
 
-typescriptRuleTester.run(
-  "TypeScript-specific",
-  plugin.rules.sort,
-  typescriptTests
-);
+// typescriptRuleTester.run(
+//   "TypeScript-specific",
+//   plugin.rules.sort,
+//   typescriptTests
+// );

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -96,7 +96,7 @@ const baseTests = (expect) => ({
     `export const three = 3;`,
     `export function f() {}`,
     `export class C {}`,
-    `export { a, b as c };`,
+    `export { a, b as c }; var a, b;`,
     `export default whatever;`,
 
     // Side-effect only imports are kept in the original order.
@@ -430,9 +430,11 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export { e, b, a as c }`,
+      code: `export { e, b, a as c }; var e, b, a;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export { a as c,b, e }`);
+        expect(actual).toMatchInlineSnapshot(
+          `export { a as c,b, e }; var e, v, a;`
+        );
       },
       errors: 1,
     },
@@ -468,9 +470,11 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export { e, b, a as c, }`,
+      code: `export { e, b, a as c, }; var e, b, a;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export { a as c,b, e,  }`);
+        expect(actual).toMatchInlineSnapshot(
+          `export { a as c,b, e,  }; var e, b, a;`
+        );
       },
       errors: 1,
     },
@@ -495,9 +499,11 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export { a as c, a as b2, b, a }`,
+      code: `export { a as c, a as b2, b, a }; var a, b;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export { a,a as b2, a as c, b }`);
+        expect(actual).toMatchInlineSnapshot(
+          `export { a,a as b2, a as c, b }; var a, b;`
+        );
       },
       errors: 1,
     },
@@ -682,15 +688,6 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
-    {
-      code: `export { aaNotKeyword, zzNotKeyword, abstract, as, asserts, any, async, /*await,*/ boolean, constructor, declare, get, infer, is, keyof, module, namespace, never, readonly, require, number, object, set, string, symbol, type, undefined, unique, unknown, from, global, bigint, of };`,
-      output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(
-          `export { aaNotKeyword, abstract, any, as, asserts, async, /*await,*/ bigint, boolean, constructor, declare, from, get, global, infer, is, keyof, module, namespace, never, number, object, of,readonly, require, set, string, symbol, type, undefined, unique, unknown, zzNotKeyword };`
-        );
-      },
-      errors: 1,
-    },
 
     // No spaces in specifiers.
     {
@@ -712,9 +709,11 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export {e,b,a as c}`,
+      code: `export {e,b,a as c}; var e, b, a;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export {a as c,b,e}`);
+        expect(actual).toMatchInlineSnapshot(
+          `export {a as c,b,e}; var e, b, a;`
+        );
       },
       errors: 1,
     },
@@ -739,9 +738,9 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export { b,a}`,
+      code: `export { b,a}; var b, a;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export { a,b}`);
+        expect(actual).toMatchInlineSnapshot(`export { a,b}; var b, a;`);
       },
       errors: 1,
     },
@@ -766,9 +765,9 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export {b,a }`,
+      code: `export {b,a }; var b, a;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export {a,b }`);
+        expect(actual).toMatchInlineSnapshot(`export {a,b }; var b, a;`);
       },
       errors: 1,
     },
@@ -793,9 +792,9 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export {b,a, }`,
+      code: `export {b,a, }; var b, a;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export {a,b, }`);
+        expect(actual).toMatchInlineSnapshot(`export {a,b, }; var b, a;`);
       },
       errors: 1,
     },
@@ -959,9 +958,11 @@ const baseTests = (expect) => ({
       errors: 1,
     },
     {
-      code: `export { b /* b */, a }`,
+      code: `export { b /* b */, a }; var b, a;`,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(`export { a,b /* b */ }`);
+        expect(actual).toMatchInlineSnapshot(
+          `export { a,b /* b */ }; var b, a;`
+        );
       },
       errors: 1,
     },
@@ -1808,6 +1809,7 @@ const baseTests = (expect) => ({
           |*/
           |
           |require("c"); import x7 from "b"; import x8 from "a"; export {x9}; require("c")
+          |var x8
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -1836,6 +1838,7 @@ const baseTests = (expect) => ({
           |require("c"); import x8 from "a"; 
           |import x7 from "b";
           |export {x8}; require("c")
+          |var x8
         `);
       },
       errors: 4,
@@ -2063,6 +2066,7 @@ const baseTests = (expect) => ({
           |  /* c0
           |*/ /*c1*/ /*c2*/export {c} from 'c' ; /*c3*/ export {a} from "a" /*a*/ /*
           |   x1 */ /* x2 */
+          |var d
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -2078,6 +2082,7 @@ const baseTests = (expect) => ({
           |// above d
           |  export {d} /*d1*/ from   "d" ; /* d2 */ /*
           |   x1 */ /* x2 */
+          |var d
         `);
       },
       errors: 1,
@@ -2800,6 +2805,7 @@ const baseTests = (expect) => ({
           |export {a} from "a"    
           |export {e}; /* multiline
           |comment 2 */ export {f} from "f";
+          |var e
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -2813,6 +2819,7 @@ const baseTests = (expect) => ({
           |export {e}; 
           |/* multiline
           |comment 2 */ export {f} from "f";
+          |var e
         `);
       },
       errors: 1,
@@ -3316,6 +3323,7 @@ const baseTests = (expect) => ({
           |
           |  4
           |;[].forEach()
+          |var c1, b1, a;
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot();
@@ -3334,7 +3342,7 @@ const flowTests = {
     `import type {} from "a"`,
     `import type {    } from "a"`,
     `export type T = string;`,
-    `export type { T, U as V };`,
+    `export type { T, U as V }; type T = 1; type U = 1;`,
 
     // typeof
     `import typeof a from "a"`,
@@ -3702,7 +3710,7 @@ const typescriptTests = {
     `import type {} from "a"`,
     `import type {    } from "a"`,
     `export type T = string;`,
-    `export type { T, U as V };`,
+    `export type { T, U as V }; type T = 1; type U = 1;`,
 
     // Sorted alphabetically.
     input`

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -467,6 +467,13 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: `export { e, b, a as c, }`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export { a as c,b, e,  }`);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with renames.
     {
@@ -484,6 +491,13 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(
           `export { a,a as b2, a as c, b } from "specifiers-renames"`
         );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { a as c, a as b2, b, a }`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export { a,a as b2, a as c, b }`);
       },
       errors: 1,
     },
@@ -595,6 +609,59 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  B,
+          |  a,
+          |  A,
+          |  b,
+          |  B2,
+          |  bb,
+          |  BB,
+          |  bB,
+          |  Bb,
+          |  ab,
+          |  ba,
+          |  Ba,
+          |  BA,
+          |  bA,
+          |  x as d,
+          |  x as C,
+          |  img10,
+          |  img2,
+          |  img1,
+          |  img10_black,
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  A,
+          |  a,
+          |  ab,
+          |  B,
+          |  b,
+          |  B2,
+          |  BA,
+          |  Ba,
+          |  bA,
+          |  ba,
+          |  BB,
+          |  Bb,
+          |  bB,
+          |  bb,
+          |  img1,
+          |  img2,
+          |  img10,
+          |  img10_black,
+          |  x as C,
+          |  x as d,
+          |}
+        `);
+      },
+      errors: 1,
+    },
 
     // Keyword-like specifiers.
     {
@@ -611,6 +678,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `export { aaNotKeyword, abstract, any, as, asserts, async, /*await,*/ bigint, boolean, constructor, declare, from, get, global, infer, is, keyof, module, namespace, never, number, object, of,readonly, require, set, string, symbol, type, undefined, unique, unknown, zzNotKeyword } from 'keyword-identifiers';`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { aaNotKeyword, zzNotKeyword, abstract, as, asserts, any, async, /*await,*/ boolean, constructor, declare, get, infer, is, keyof, module, namespace, never, readonly, require, number, object, set, string, symbol, type, undefined, unique, unknown, from, global, bigint, of };`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { aaNotKeyword, abstract, any, as, asserts, async, /*await,*/ bigint, boolean, constructor, declare, from, get, global, infer, is, keyof, module, namespace, never, number, object, of,readonly, require, set, string, symbol, type, undefined, unique, unknown, zzNotKeyword };`
         );
       },
       errors: 1,
@@ -635,6 +711,13 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: `export {e,b,a as c}`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export {a as c,b,e}`);
+      },
+      errors: 1,
+    },
 
     // Space before specifiers.
     {
@@ -652,6 +735,13 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(
           `export { a,b} from "specifiers-no-space-before"`
         );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { b,a}`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export { a,b}`);
       },
       errors: 1,
     },
@@ -675,6 +765,13 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: `export {b,a }`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export {a,b }`);
+      },
+      errors: 1,
+    },
 
     // Space after specifiers.
     {
@@ -692,6 +789,13 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(
           `export {a,b, } from "specifiers-no-space-after-trailing"`
         );
+      },
+      errors: 1,
+    },
+    {
+      code: `export {b,a, }`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export {a,b, }`);
       },
       errors: 1,
     },
@@ -743,6 +847,29 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  // c
+          |  c,
+          |  b, // b
+          |  a
+          |  // last
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,
+          |  b, // b
+          |  // c
+          |  c
+          |  // last
+          |}
+        `);
+      },
+      errors: 1,
+    },
 
     // Comment after last specifier should stay last.
     {
@@ -789,6 +916,28 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  // c
+          |  c,b, // b
+          |  a
+          |  // last
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,
+          |b, // b
+          |  // c
+          |  c
+          |  // last
+          |}
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with comment between.
     {
@@ -806,6 +955,13 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(
           `export { a,b /* b */ } from "specifiers-comment-between"`
         );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { b /* b */, a }`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export { a,b /* b */ }`);
       },
       errors: 1,
     },
@@ -849,6 +1005,27 @@ const baseTests = (expect) => ({
           |  // x
           |  // y
           |} from "specifiers-trailing"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |  c,
+          |  a,
+          |  // x
+          |  // y
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,
+          |  c,
+          |  // x
+          |  // y
+          |}
         `);
       },
       errors: 1,
@@ -903,6 +1080,30 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  /*c1*/ c, /*c2*/ /*a1
+          |  */a, /*a2*/ /*
+          |  after */
+          |  // x
+          |  // y
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |/*a1
+          |  */a, /*a2*/ 
+          |  /*c1*/ c, /*c2*/ /*
+          |  after */
+          |  // x
+          |  // y
+          |}
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with multiline end comment.
     {
@@ -937,6 +1138,24 @@ const baseTests = (expect) => ({
           |  a,   b/*
           |  after */
           |} from "specifiers-multiline-end-comment"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |  b,
+          |  a /*
+          |  after */
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,   b/*
+          |  after */
+          |}
         `);
       },
       errors: 1,
@@ -983,6 +1202,26 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  b,
+          |  a /*a*/
+          |  /*
+          |  after */
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a, /*a*/
+          |  b  /*
+          |  after */
+          |}
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with multiline end comment and no newline.
     {
@@ -1017,6 +1256,22 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  b,
+          |  a /*
+          |  after */ }
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,   b/*
+          |  after */ }
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with lots of comments.
     {
@@ -1033,6 +1288,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `/*1*//*2*/export/*3*//*4*/{/*{*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/b/*b1*/,/*b2*/e/*e1*/,/*e2*//*e3*/}/*5*/from/*6*/"specifiers-lots-of-comments"/*7*//*8*/`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `/*1*//*2*/export/*3*//*4*/{/*{*/e/*e1*/,/*e2*//*e3*/b/*b1*/,/*b2*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/}/*5*//*6*//*7*//*8*/`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `/*1*//*2*/export/*3*//*4*/{/*{*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/b/*b1*/,/*b2*/e/*e1*/,/*e2*//*e3*/}/*5*//*6*//*7*//*8*/`
         );
       },
       errors: 1,
@@ -1115,6 +1379,44 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export { // start
+          |  /* c1 */ c /* c2 */, // c3
+          |  // b1
+          |
+          |  b as /* b2 */ renamed
+          |  , /* b3 */ /* a1
+          |  */ a /* not-a
+          |  */ // comment at end
+          |};
+          |export {
+          |  e,
+          |  d, /* d */ /* not-d
+          |  */ // comment at end after trailing comma
+          |};
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export { // start
+          |/* a1
+          |  */ a, 
+          |  // b1
+          |  b as /* b2 */ renamed
+          |  , /* b3 */ 
+          |  /* c1 */ c /* c2 */// c3
+          |/* not-a
+          |  */ // comment at end
+          |};
+          |export {
+          |  d, /* d */   e,
+          |/* not-d
+          |  */ // comment at end after trailing comma
+          |};
+        `);
+      },
+      errors: 1,
+    },
 
     // No empty line after last specifier due to newline before comma.
     {
@@ -1149,6 +1451,24 @@ const baseTests = (expect) => ({
           |  a,
           |  b/*b*/
           |  } from "specifiers-blank";
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |  b/*b*/
+          |  ,
+          |  a
+          |};
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,
+          |  b/*b*/
+          |  };
         `);
       },
       errors: 1,
@@ -1209,6 +1529,33 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {z, y,
+          |  x,
+          |
+          |w,
+          |    v
+          |  as /*v*/
+          |
+          |    u , t /*t*/, // t
+          |    s
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {    s,
+          |t /*t*/, // t
+          |    v
+          |  as /*v*/
+          |    u , w,
+          |  x,
+          |y,
+          |z}
+        `);
+      },
+      errors: 1,
+    },
 
     // Indent: 0.
     {
@@ -1241,6 +1588,23 @@ const baseTests = (expect) => ({
           |a,
           |b,
           |} from "specifiers-indent-0"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |b,
+          |a,
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |a,
+          |b,
+          |}
         `);
       },
       errors: 1,
@@ -1281,6 +1645,23 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |    b,
+          |    a,
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |    a,
+          |    b,
+          |}
+        `);
+      },
+      errors: 1,
+    },
 
     // Indent: tab.
     {
@@ -1313,6 +1694,23 @@ const baseTests = (expect) => ({
           |→a,
           |→b,
           |} from "specifiers-indent-tab"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |\tb,
+          |\ta,
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |→a,
+          |→b,
+          |}
         `);
       },
       errors: 1,
@@ -1359,6 +1757,28 @@ const baseTests = (expect) => ({
           |→b,
           |    c,
           |} from "specifiers-indent-mixed"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          | //
+          |\tb,
+          |  a,
+          |
+          |    c,
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,
+          | //
+          |→b,
+          |    c,
+          |}
         `);
       },
       errors: 1,

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1555,6 +1555,166 @@ const baseTests = (expect) => ({
       errors: 1,
     },
 
+    // https://github.com/facebook/react/blob/4c7036e807fa18a3e21a5182983c7c0f05c5936e/packages/react-dom/src/client/ReactDOM.js#L193-L217
+    {
+      code: input`
+          |export {
+          |  createPortal,
+          |  batchedUpdates as unstable_batchedUpdates,
+          |  flushSync,
+          |  Internals as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+          |  ReactVersion as version,
+          |  // Disabled behind disableLegacyReactDOMAPIs
+          |  findDOMNode,
+          |  hydrate,
+          |  render,
+          |  unmountComponentAtNode,
+          |  // exposeConcurrentModeAPIs
+          |  createRoot,
+          |  createBlockingRoot,
+          |  flushControlled as unstable_flushControlled,
+          |  scheduleHydration as unstable_scheduleHydration,
+          |  // Disabled behind disableUnstableRenderSubtreeIntoContainer
+          |  renderSubtreeIntoContainer as unstable_renderSubtreeIntoContainer,
+          |  // Disabled behind disableUnstableCreatePortal
+          |  // Temporary alias since we already shipped React 16 RC with it.
+          |  // TODO: remove in React 18.
+          |  unstable_createPortal,
+          |  // enableCreateEventHandleAPI
+          |  createEventHandle as unstable_createEventHandle,
+          |};
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  batchedUpdates as unstable_batchedUpdates,
+          |  createBlockingRoot,
+          |  // enableCreateEventHandleAPI
+          |  createEventHandle as unstable_createEventHandle,
+          |  createPortal,
+          |  // exposeConcurrentModeAPIs
+          |  createRoot,
+          |  // Disabled behind disableLegacyReactDOMAPIs
+          |  findDOMNode,
+          |  flushControlled as unstable_flushControlled,
+          |  flushSync,
+          |  hydrate,
+          |  Internals as __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+          |  ReactVersion as version,
+          |  render,
+          |  // Disabled behind disableUnstableRenderSubtreeIntoContainer
+          |  renderSubtreeIntoContainer as unstable_renderSubtreeIntoContainer,
+          |  scheduleHydration as unstable_scheduleHydration,
+          |  unmountComponentAtNode,
+          |  // Disabled behind disableUnstableCreatePortal
+          |  // Temporary alias since we already shipped React 16 RC with it.
+          |  // TODO: remove in React 17.
+          |  unstable_createPortal,
+          |};
+        `);
+      },
+      errors: 1,
+    },
+
+    // https://github.com/apollographql/apollo-client/blob/39942881567ff9825a0f17bbf114ec441590f8bb/src/core/index.ts#L1-L98
+    {
+      code: input`
+          |export {
+          |/* Core */
+          |
+          |export {
+          |  ApolloClient,
+          |  ApolloClientOptions,
+          |  DefaultOptions
+          |} from '../ApolloClient';
+          |export {
+          |  ObservableQuery,
+          |  FetchMoreOptions,
+          |  UpdateQueryOptions,
+          |  ApolloCurrentQueryResult,
+          |} from '../core/ObservableQuery';
+          |export {
+          |  QueryBaseOptions,
+          |  QueryOptions,
+          |  WatchQueryOptions,
+          |  MutationOptions,
+          |  SubscriptionOptions,
+          |  FetchPolicy,
+          |  WatchQueryFetchPolicy,
+          |  ErrorPolicy,
+          |  FetchMoreQueryOptions,
+          |  SubscribeToMoreOptions,
+          |  MutationUpdaterFn,
+          |} from '../core/watchQueryOptions';
+          |export { NetworkStatus } from '../core/networkStatus';
+          |export * from '../core/types';
+          |export {
+          |  Resolver,
+          |  FragmentMatcher as LocalStateFragmentMatcher,
+          |} from '../core/LocalState';
+          |export { isApolloError, ApolloError } from '../errors/ApolloError';
+          |
+          |/* Cache */
+          |
+          |export * from '../cache';
+          |
+          |/* Link */
+          |
+          |export { empty } from '../link/core/empty';
+          |export { from } from '../link/core/from';
+          |export { split } from '../link/core/split';
+          |export { concat } from '../link/core/concat';
+          |export { execute } from '../link/core/execute';
+          |export { ApolloLink } from '../link/core/ApolloLink';
+          |export * from '../link/core/types';
+          |export {
+          |  parseAndCheckHttpResponse,
+          |  ServerParseError
+          |} from '../link/http/parseAndCheckHttpResponse';
+          |export {
+          |  serializeFetchParameter,
+          |  ClientParseError
+          |} from '../link/http/serializeFetchParameter';
+          |export {
+          |  HttpOptions,
+          |  fallbackHttpConfig,
+          |  selectHttpOptionsAndBody,
+          |  UriFunction
+          |} from '../link/http/selectHttpOptionsAndBody';
+          |export { checkFetcher } from '../link/http/checkFetcher';
+          |export { createSignalIfSupported } from '../link/http/createSignalIfSupported';
+          |export { selectURI } from '../link/http/selectURI';
+          |export { createHttpLink } from '../link/http/createHttpLink';
+          |export { HttpLink } from '../link/http/HttpLink';
+          |export { fromError } from '../link/utils/fromError';
+          |export { toPromise } from '../link/utils/toPromise';
+          |export { fromPromise } from '../link/utils/fromPromise';
+          |export { ServerError, throwServerError } from '../link/utils/throwServerError';
+          |export {
+          |  Observable,
+          |  Observer,
+          |  ObservableSubscription
+          |} from '../utilities/observables/Observable';
+          |
+          |/* Supporting */
+          |
+          |// Note that importing \`gql\` by itself, then destructuring
+          |// additional properties separately before exporting, is intentional...
+          |import gql from 'graphql-tag';
+          |export const {
+          |  resetCaches,
+          |  disableFragmentWarnings,
+          |  enableExperimentalFragmentVariables,
+          |  disableExperimentalFragmentVariables
+          |} = gql;
+          |export { gql };
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot();
+      },
+      errors: 1,
+    },
+
     // `groups` – `u` flag.
     {
       options: [{ groups: [["^\\p{L}"], ["^\\."]] }],
@@ -1906,6 +2066,132 @@ const flowTests = {
       },
       errors: 1,
     },
+
+    // https://github.com/graphql/graphql-js/blob/f7061fdcf461a2e4b3c78077afaebefc2226c8e3/src/utilities/index.js#L1-L115
+    {
+      code: input`
+          |import { forEach, isCollection } from 'iterall';
+          |// @flow strict
+          |
+          |// Produce the GraphQL query recommended for a full schema introspection.
+          |// Accepts optional IntrospectionOptions.
+          |export { getIntrospectionQuery } from './getIntrospectionQuery';
+          |
+          |export type {
+          |  IntrospectionOptions,
+          |  IntrospectionQuery,
+          |  IntrospectionSchema,
+          |  IntrospectionType,
+          |  IntrospectionInputType,
+          |  IntrospectionOutputType,
+          |  IntrospectionScalarType,
+          |  IntrospectionObjectType,
+          |  IntrospectionInterfaceType,
+          |  IntrospectionUnionType,
+          |  IntrospectionEnumType,
+          |  IntrospectionInputObjectType,
+          |  IntrospectionTypeRef,
+          |  IntrospectionInputTypeRef,
+          |  IntrospectionOutputTypeRef,
+          |  IntrospectionNamedTypeRef,
+          |  IntrospectionListTypeRef,
+          |  IntrospectionNonNullTypeRef,
+          |  IntrospectionField,
+          |  IntrospectionInputValue,
+          |  IntrospectionEnumValue,
+          |  IntrospectionDirective,
+          |} from './getIntrospectionQuery';
+          |
+          |// Gets the target Operation from a Document.
+          |export { getOperationAST } from './getOperationAST';
+          |
+          |// Gets the Type for the target Operation AST.
+          |export { getOperationRootType } from './getOperationRootType';
+          |
+          |// Convert a GraphQLSchema to an IntrospectionQuery.
+          |export { introspectionFromSchema } from './introspectionFromSchema';
+          |
+          |// Build a GraphQLSchema from an introspection result.
+          |export { buildClientSchema } from './buildClientSchema';
+          |
+          |// Build a GraphQLSchema from GraphQL Schema language.
+          |export { buildASTSchema, buildSchema } from './buildASTSchema';
+          |export type { BuildSchemaOptions } from './buildASTSchema';
+          |
+          |// Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
+          |export {
+          |  extendSchema,
+          |  // @deprecated: Get the description from a schema AST node and supports legacy
+          |  // syntax for specifying descriptions - will be removed in v16.
+          |  getDescription,
+          |} from './extendSchema';
+          |
+          |// Sort a GraphQLSchema.
+          |export { lexicographicSortSchema } from './lexicographicSortSchema';
+          |
+          |// Print a GraphQLSchema to GraphQL Schema language.
+          |export {
+          |  printSchema,
+          |  printType,
+          |  printIntrospectionSchema,
+          |} from './printSchema';
+          |
+          |// Create a GraphQLType from a GraphQL language AST.
+          |export { typeFromAST } from './typeFromAST';
+          |
+          |// Create a JavaScript value from a GraphQL language AST with a type.
+          |export { valueFromAST } from './valueFromAST';
+          |
+          |// Create a JavaScript value from a GraphQL language AST without a type.
+          |export { valueFromASTUntyped } from './valueFromASTUntyped';
+          |
+          |// Create a GraphQL language AST from a JavaScript value.
+          |export { astFromValue } from './astFromValue';
+          |
+          |// A helper to use within recursive-descent visitors which need to be aware of
+          |// the GraphQL type system.
+          |export { TypeInfo, visitWithTypeInfo } from './TypeInfo';
+          |
+          |// Coerces a JavaScript value to a GraphQL type, or produces errors.
+          |export { coerceInputValue } from './coerceInputValue';
+          |
+          |// Concatenates multiple AST together.
+          |export { concatAST } from './concatAST';
+          |
+          |// Separates an AST into an AST per Operation.
+          |export { separateOperations } from './separateOperations';
+          |
+          |// Strips characters that are not significant to the validity or execution
+          |// of a GraphQL document.
+          |export { stripIgnoredCharacters } from './stripIgnoredCharacters';
+          |
+          |// Comparators for types
+          |export {
+          |  isEqualType,
+          |  isTypeSubTypeOf,
+          |  doTypesOverlap,
+          |} from './typeComparators';
+          |
+          |// Asserts that a string is a valid GraphQL name
+          |export { assertValidName, isValidNameError } from './assertValidName';
+          |
+          |// Compares two GraphQLSchemas and detects breaking changes.
+          |export {
+          |  BreakingChangeType,
+          |  DangerousChangeType,
+          |  findBreakingChanges,
+          |  findDangerousChanges,
+          |} from './findBreakingChanges';
+          |export type { BreakingChange, DangerousChange } from './findBreakingChanges';
+          |
+          |// Report all deprecated usage within a GraphQL document.
+          |export { findDeprecatedUsages } from './findDeprecatedUsages';
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot();
+      },
+      errors: 1,
+    },
   ],
 };
 
@@ -1937,6 +2223,7 @@ const typescriptTests = {
     `,
   ],
   invalid: [
+    // Type imports.
     {
       code: input`
           |import React from "react";
@@ -1974,6 +2261,47 @@ const typescriptTests = {
           |  return names.map(n => o[n]);
           |}
         `);
+      },
+      errors: 1,
+    },
+
+    // https://github.com/apollographql/apollo-client/blob/39942881567ff9825a0f17bbf114ec441590f8bb/src/core/QueryInfo.ts#L1-L39
+    {
+      code: input`
+          |import React from "react";
+          |import { DocumentNode, GraphQLError } from 'graphql';
+          |import { equal } from "@wry/equality";
+          |
+          |import { Cache } from '../cache/core/types/Cache';
+          |import { ApolloCache } from '../cache/core/cache';
+          |import { WatchQueryOptions } from './watchQueryOptions';
+          |import { ObservableQuery } from './ObservableQuery';
+          |import { QueryListener } from './types';
+          |import { FetchResult } from '../link/core/types';
+          |import { ObservableSubscription } from '../utilities/observables/Observable';
+          |import { isNonEmptyArray } from '../utilities/common/arrays';
+          |import { graphQLResultHasError } from '../utilities/common/errorHandling';
+          |import {
+          |  NetworkStatus,
+          |  isNetworkRequestInFlight,
+          |} from './networkStatus';
+          |import { ApolloError } from '../errors/ApolloError';
+          |
+          |export type QueryStoreValue = Pick<QueryInfo,
+          |  | "variables"
+          |  | "networkStatus"
+          |  | "networkError"
+          |  | "graphQLErrors"
+          |  >;
+          |
+          |// A QueryInfo object represents a single query managed by the
+          |// QueryManager, which tracks all QueryInfo objects by queryId in its...
+          |export class QueryInfo {
+          |  listeners = new Set<QueryListener>();
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot();
       },
       errors: 1,
     },

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -424,7 +424,7 @@ const baseTests = (expect) => ({
       code: `export { e, b, a as c } from "specifiers"`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export { a as c,b, e } from "specifiers"`
+          `export { b, a as c,e } from "specifiers"`
         );
       },
       errors: 1,
@@ -464,7 +464,7 @@ const baseTests = (expect) => ({
       code: `export { e, b, a as c, } from "specifiers-trailing-comma"`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export { a as c,b, e,  } from "specifiers-trailing-comma"`
+          `export { b, a as c,e,  } from "specifiers-trailing-comma"`
         );
       },
       errors: 1,
@@ -493,7 +493,7 @@ const baseTests = (expect) => ({
       code: `export { a as c, a as b2, b, a } from "specifiers-renames"`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export { a,a as b2, a as c, b } from "specifiers-renames"`
+          `export { a,b, a as b2, a as c } from "specifiers-renames"`
         );
       },
       errors: 1,
@@ -604,12 +604,12 @@ const baseTests = (expect) => ({
           |  Bb,
           |  bB,
           |  bb,
+          |  x as C,
+          |  x as d,
           |  img1,
           |  img2,
           |  img10,
           |  img10_black,
-          |  x as C,
-          |  x as d,
           |} from "specifiers-human-sort"
         `);
       },
@@ -703,7 +703,7 @@ const baseTests = (expect) => ({
       code: `export {e,b,a as c} from "specifiers-no-spaces"`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export {a as c,b,e} from "specifiers-no-spaces"`
+          `export {b,a as c,e} from "specifiers-no-spaces"`
         );
       },
       errors: 1,
@@ -1288,16 +1288,7 @@ const baseTests = (expect) => ({
       code: `/*1*//*2*/export/*3*//*4*/{/*{*/e/*e1*/,/*e2*//*e3*/b/*b1*/,/*b2*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/}/*5*/from/*6*/"specifiers-lots-of-comments"/*7*//*8*/`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `/*1*//*2*/export/*3*//*4*/{/*{*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/b/*b1*/,/*b2*/e/*e1*/,/*e2*//*e3*/}/*5*/from/*6*/"specifiers-lots-of-comments"/*7*//*8*/`
-        );
-      },
-      errors: 1,
-    },
-    {
-      code: `/*1*//*2*/export/*3*//*4*/{/*{*/e/*e1*/,/*e2*//*e3*/b/*b1*/,/*b2*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/}/*5*//*6*//*7*//*8*/`,
-      output: (actual) => {
-        expect(actual).toMatchInlineSnapshot(
-          `/*1*//*2*/export/*3*//*4*/{/*{*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/b/*b1*/,/*b2*/e/*e1*/,/*e2*//*e3*/}/*5*//*6*//*7*//*8*/`
+          `/*1*//*2*/export/*3*//*4*/{/*{*/b/*b1*/,/*b2*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/e/*e1*/,/*e2*//*e3*/}/*5*/from/*6*/"specifiers-lots-of-comments"/*7*//*8*/`
         );
       },
       errors: 1,
@@ -1364,11 +1355,10 @@ const baseTests = (expect) => ({
           |export { // start
           |/* a1
           |  */ a, 
+          |  /* c1 */ c /* c2 */, // c3
           |  // b1
           |  b as /* b2 */ renamed
-          |  , /* b3 */ 
-          |  /* c1 */ c /* c2 */// c3
-          |/* not-a
+          |  /* b3 */ /* not-a
           |  */ // comment at end
           |} from "specifiers-lots-of-comments-multiline";
           |export {
@@ -1396,6 +1386,7 @@ const baseTests = (expect) => ({
           |  d, /* d */ /* not-d
           |  */ // comment at end after trailing comma
           |};
+          |var c, b, a, e, d;
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -1414,6 +1405,7 @@ const baseTests = (expect) => ({
           |/* not-d
           |  */ // comment at end after trailing comma
           |};
+          |var c, b, a, e, d;
         `);
       },
       errors: 1,
@@ -2523,6 +2515,12 @@ const baseTests = (expect) => ({
           |/* default */
           |// default
           | {
+          |  /* b
+          |   */
+          |  b // b
+          |  ,
+          |  // c
+          |  c /*c*/,
           |  // a1
           |  // a2
           |  a
@@ -2532,12 +2530,6 @@ const baseTests = (expect) => ({
           |  d
           |  // a5
           |  , // a6
-          |  /* b
-          |   */
-          |  b // b
-          |  ,
-          |  // c
-          |  c /*c*/,
           |  // last
           |}
           |// from1
@@ -2815,10 +2807,10 @@ const baseTests = (expect) => ({
           |export {b} from "b";    
           |export {c} from "c";  /* comment */  
           |export {d} from "d";  
-          |
-          |export {e}; 
           |/* multiline
           |comment 2 */ export {f} from "f";
+          |
+          |export {e}; 
           |var e
         `);
       },
@@ -3577,7 +3569,6 @@ const flowTests = {
     // https://github.com/graphql/graphql-js/blob/f7061fdcf461a2e4b3c78077afaebefc2226c8e3/src/utilities/index.js#L1-L115
     {
       code: input`
-          |import { forEach, isCollection } from 'iterall';
           |// @flow strict
           |
           |// Produce the GraphQL query recommended for a full schema introspection.
@@ -3695,7 +3686,101 @@ const flowTests = {
           |export { findDeprecatedUsages } from './findDeprecatedUsages';
       `,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot();
+        expect(actual).toMatchInlineSnapshot(`
+          |// @flow strict
+          |
+          |// Produce the GraphQL query recommended for a full schema introspection.
+          |// Accepts optional IntrospectionOptions.
+          |// Asserts that a string is a valid GraphQL name
+          |export { assertValidName, isValidNameError } from './assertValidName';
+          |// Create a GraphQL language AST from a JavaScript value.
+          |export { astFromValue } from './astFromValue';
+          |export type { BuildSchemaOptions } from './buildASTSchema';
+          |// Build a GraphQLSchema from GraphQL Schema language.
+          |export { buildASTSchema, buildSchema } from './buildASTSchema';
+          |// Build a GraphQLSchema from an introspection result.
+          |export { buildClientSchema } from './buildClientSchema';
+          |// Coerces a JavaScript value to a GraphQL type, or produces errors.
+          |export { coerceInputValue } from './coerceInputValue';
+          |// Concatenates multiple AST together.
+          |export { concatAST } from './concatAST';
+          |// Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
+          |export {
+          |  extendSchema,
+          |  // @deprecated: Get the description from a schema AST node and supports legacy
+          |  // syntax for specifying descriptions - will be removed in v16.
+          |  getDescription,
+          |} from './extendSchema';
+          |export type { BreakingChange, DangerousChange } from './findBreakingChanges';
+          |// Compares two GraphQLSchemas and detects breaking changes.
+          |export {
+          |  BreakingChangeType,
+          |  DangerousChangeType,
+          |  findBreakingChanges,
+          |  findDangerousChanges,
+          |} from './findBreakingChanges';
+          |// Report all deprecated usage within a GraphQL document.
+          |export { findDeprecatedUsages } from './findDeprecatedUsages';
+          |export type {
+          |  IntrospectionDirective,
+          |  IntrospectionEnumType,
+          |  IntrospectionEnumValue,
+          |  IntrospectionField,
+          |  IntrospectionInputObjectType,
+          |  IntrospectionInputType,
+          |  IntrospectionInputTypeRef,
+          |  IntrospectionInputValue,
+          |  IntrospectionInterfaceType,
+          |  IntrospectionListTypeRef,
+          |  IntrospectionNamedTypeRef,
+          |  IntrospectionNonNullTypeRef,
+          |  IntrospectionObjectType,
+          |  IntrospectionOptions,
+          |  IntrospectionOutputType,
+          |  IntrospectionOutputTypeRef,
+          |  IntrospectionQuery,
+          |  IntrospectionScalarType,
+          |  IntrospectionSchema,
+          |  IntrospectionType,
+          |  IntrospectionTypeRef,
+          |  IntrospectionUnionType,
+          |} from './getIntrospectionQuery';
+          |export { getIntrospectionQuery } from './getIntrospectionQuery';
+          |// Gets the target Operation from a Document.
+          |export { getOperationAST } from './getOperationAST';
+          |// Gets the Type for the target Operation AST.
+          |export { getOperationRootType } from './getOperationRootType';
+          |// Convert a GraphQLSchema to an IntrospectionQuery.
+          |export { introspectionFromSchema } from './introspectionFromSchema';
+          |// Sort a GraphQLSchema.
+          |export { lexicographicSortSchema } from './lexicographicSortSchema';
+          |// Print a GraphQLSchema to GraphQL Schema language.
+          |export {
+          |  printIntrospectionSchema,
+          |  printSchema,
+          |  printType,
+          |} from './printSchema';
+          |// Separates an AST into an AST per Operation.
+          |export { separateOperations } from './separateOperations';
+          |// Strips characters that are not significant to the validity or execution
+          |// of a GraphQL document.
+          |export { stripIgnoredCharacters } from './stripIgnoredCharacters';
+          |// Comparators for types
+          |export {
+          |  doTypesOverlap,
+          |  isEqualType,
+          |  isTypeSubTypeOf,
+          |} from './typeComparators';
+          |// Create a GraphQLType from a GraphQL language AST.
+          |export { typeFromAST } from './typeFromAST';
+          |// A helper to use within recursive-descent visitors which need to be aware of
+          |// the GraphQL type system.
+          |export { TypeInfo, visitWithTypeInfo } from './TypeInfo';
+          |// Create a JavaScript value from a GraphQL language AST with a type.
+          |export { valueFromAST } from './valueFromAST';
+          |// Create a JavaScript value from a GraphQL language AST without a type.
+          |export { valueFromASTUntyped } from './valueFromASTUntyped';
+        `);
       },
       errors: 1,
     },
@@ -3834,7 +3919,38 @@ const typescriptTests = {
           |}
       `,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot();
+        expect(actual).toMatchInlineSnapshot(`
+          |import { equal } from "@wry/equality";
+          |import { DocumentNode, GraphQLError } from 'graphql';
+          |import React from "react";
+          |
+          |import { ApolloCache } from '../cache/core/cache';
+          |import { Cache } from '../cache/core/types/Cache';
+          |import { ApolloError } from '../errors/ApolloError';
+          |import { FetchResult } from '../link/core/types';
+          |import { isNonEmptyArray } from '../utilities/common/arrays';
+          |import { graphQLResultHasError } from '../utilities/common/errorHandling';
+          |import { ObservableSubscription } from '../utilities/observables/Observable';
+          |import {
+          |  isNetworkRequestInFlight,
+          |  NetworkStatus,
+          |} from './networkStatus';
+          |import { ObservableQuery } from './ObservableQuery';
+          |import { QueryListener } from './types';
+          |import { WatchQueryOptions } from './watchQueryOptions';
+          |
+          |export type QueryStoreValue = Pick<QueryInfo,
+          |  | "variables"
+          |  | "networkStatus"
+          |  | "networkError"
+          |  | "graphQLErrors"
+          |  >;
+          |// A QueryInfo object represents a single query managed by the
+          |// QueryManager, which tracks all QueryInfo objects by queryId in its...
+          |export class QueryInfo {
+          |  listeners = new Set<QueryListener>();
+          |}
+        `);
       },
       errors: 1,
     },

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -3105,7 +3105,106 @@ const baseTests = (expect) => ({
           |export { gql };
       `,
       output: (actual) => {
-        expect(actual).toMatchInlineSnapshot();
+        expect(actual).toMatchInlineSnapshot(`
+          |/* Core */
+          |
+          |/* Supporting */
+          |// Note that importing \`gql\` by itself, then destructuring
+          |// additional properties separately before exporting, is intentional...
+          |import gql from 'graphql-tag';
+          |
+          |export {
+          |  ApolloClient,
+          |  ApolloClientOptions,
+          |  DefaultOptions
+          |} from '../ApolloClient';
+          |
+          |/* Cache */
+          |export * from '../cache';
+          |
+          |export {
+          |  FragmentMatcher as LocalStateFragmentMatcher,
+          |  Resolver,
+          |} from '../core/LocalState';
+          |
+          |export { NetworkStatus } from '../core/networkStatus';
+          |
+          |export {
+          |  ApolloCurrentQueryResult,
+          |  FetchMoreOptions,
+          |  ObservableQuery,
+          |  UpdateQueryOptions,
+          |} from '../core/ObservableQuery';
+          |
+          |export * from '../core/types';
+          |
+          |export {
+          |  ErrorPolicy,
+          |  FetchMoreQueryOptions,
+          |  FetchPolicy,
+          |  MutationOptions,
+          |  MutationUpdaterFn,
+          |  QueryBaseOptions,
+          |  QueryOptions,
+          |  SubscribeToMoreOptions,
+          |  SubscriptionOptions,
+          |  WatchQueryFetchPolicy,
+          |  WatchQueryOptions,
+          |} from '../core/watchQueryOptions';
+          |
+          |export { ApolloError,isApolloError } from '../errors/ApolloError';
+          |export { ApolloLink } from '../link/core/ApolloLink';
+          |export { concat } from '../link/core/concat';
+          |
+          |/* Link */
+          |export { empty } from '../link/core/empty';
+          |
+          |export { execute } from '../link/core/execute';
+          |export { from } from '../link/core/from';
+          |export { split } from '../link/core/split';
+          |export * from '../link/core/types';
+          |export { checkFetcher } from '../link/http/checkFetcher';
+          |export { createHttpLink } from '../link/http/createHttpLink';
+          |export { createSignalIfSupported } from '../link/http/createSignalIfSupported';
+          |export { HttpLink } from '../link/http/HttpLink';
+          |
+          |export {
+          |  parseAndCheckHttpResponse,
+          |  ServerParseError
+          |} from '../link/http/parseAndCheckHttpResponse';
+          |
+          |export {
+          |  fallbackHttpConfig,
+          |  HttpOptions,
+          |  selectHttpOptionsAndBody,
+          |  UriFunction
+          |} from '../link/http/selectHttpOptionsAndBody';
+          |
+          |export { selectURI } from '../link/http/selectURI';
+          |
+          |export {
+          |  ClientParseError,
+          |  serializeFetchParameter} from '../link/http/serializeFetchParameter';
+          |
+          |export { fromError } from '../link/utils/fromError';
+          |export { fromPromise } from '../link/utils/fromPromise';
+          |export { ServerError, throwServerError } from '../link/utils/throwServerError';
+          |export { toPromise } from '../link/utils/toPromise';
+          |
+          |export {
+          |  Observable,
+          |  ObservableSubscription,
+          |  Observer} from '../utilities/observables/Observable';
+          |
+          |export const {
+          |  resetCaches,
+          |  disableFragmentWarnings,
+          |  enableExperimentalFragmentVariables,
+          |  disableExperimentalFragmentVariables
+          |} = gql;
+          |
+          |export { gql };
+        `);
       },
       errors: 1,
     },

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -309,8 +309,10 @@ const baseTests = (expect) => ({
           |import x3 from "c"
           |import x4 from "d" ; 
           |import x5 from "e"
+          |
           |import x6 from "f"
           |;
+          |
           |import x7 from "g";[].forEach()
         `);
       },
@@ -390,6 +392,7 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |import x1 from "a"
           |;
+          |
           |import x2 from "b"
         `);
       },
@@ -436,7 +439,7 @@ const baseTests = (expect) => ({
       code: `export { e, b, a as c }; var e, b, a;`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export { a as c,b, e }; var e, v, a;`
+          `export { b, a as c,e }; var e, b, a;`
         );
       },
       errors: 1,
@@ -476,7 +479,7 @@ const baseTests = (expect) => ({
       code: `export { e, b, a as c, }; var e, b, a;`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export { a as c,b, e,  }; var e, b, a;`
+          `export { b, a as c,e,  }; var e, b, a;`
         );
       },
       errors: 1,
@@ -505,7 +508,7 @@ const baseTests = (expect) => ({
       code: `export { a as c, a as b2, b, a }; var a, b;`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export { a,a as b2, a as c, b }; var a, b;`
+          `export { a,b, a as b2, a as c }; var a, b;`
         );
       },
       errors: 1,
@@ -715,7 +718,7 @@ const baseTests = (expect) => ({
       code: `export {e,b,a as c}; var e, b, a;`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
-          `export {a as c,b,e}; var e, b, a;`
+          `export {b,a as c,e}; var e, b, a;`
         );
       },
       errors: 1,
@@ -1327,6 +1330,7 @@ const baseTests = (expect) => ({
           |/* not-a
           |  */ // comment at end
           |} from "specifiers-lots-of-comments-multiline";
+          |
           |import {
           |  d, /* d */   e,
           |/* not-d
@@ -2039,10 +2043,12 @@ const baseTests = (expect) => ({
           |/* also
           |before */ import a from "a" /*a*/ 
           |/* b */ import b from "b" // b
+          |
           |/* before
           |  c0 */ // before c1
           |  /* c0
           |*/ /*c1*/ /*c2*/import c from 'c' ; /*c3*/ 
+          |
           |// above d
           |  import d /*d1*/ from   "d" ; /* d2 */ /*
           |   x1 */ /* x2 */
@@ -2278,9 +2284,11 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |// a
           |import a from "a"
+          |
           |// b1
           |// b2
           |import b from "b"
+          |
           |import c from "c"
         `);
       },
@@ -2329,9 +2337,11 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |// a<CR>
           |import a from "a"<CR>
+          |<CR>
           |// b1<CR>
           |// b2<CR>
           |import b from "b"<CR>
+          |<CR>
           |import c from "c"<CR>
           |after();<CR>
         `);
@@ -2661,14 +2671,18 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |  /* a */ import a from "a"; 
+          |
           |  // b
           |  import {
           |    b2,
           |b3,
           |    b4  } from "b";
+          |
           |import c from "c"
+          |
           |    // d
           |    import d from "d"
+          |
           |  import e from "e"
         `);
       },
@@ -2728,14 +2742,18 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |      <CR>
           |  /* a */ import a from "a"; <CR>
+          |<CR>
           |  // b<CR>
           |  import {<CR>
           |    b2,<CR>
           |b3,<CR>
           |    b4  } from "b";<CR>
+          |<CR>
           |import c from "c"<CR>
+          |<CR>
           |    // d<CR>
           |    import d from "d"<CR>
+          |<CR>
           |  import e from "e"<CR>
           |
         `);
@@ -2796,10 +2814,12 @@ const baseTests = (expect) => ({
           |/* multiline
           |comment */  
           |import a from "a"    
+          |
           |import b from "b";    
           |import c from "c";  /* comment */  
           |import d from "d";  
           |import e from "e"; 
+          |
           |/* multiline
           |comment 2 */ import f from "f";
         `);
@@ -2826,11 +2846,8 @@ const baseTests = (expect) => ({
           |export {b} from "b";    
           |export {c} from "c";  /* comment */  
           |export {d} from "d";  
-          |
-          |/* multiline
+          |export {e}; /* multiline
           |comment 2 */ export {f} from "f";
-          |
-          |export {e}; 
           |var e
         `);
       },
@@ -2937,6 +2954,7 @@ const baseTests = (expect) => ({
           |import { connect } from 'react-redux';
           |
           |import agent from '../agent';
+          |
           |import {
           |  ADD_TAG,
           |  ARTICLE_SUBMITTED,
@@ -2945,6 +2963,7 @@ const baseTests = (expect) => ({
           |  REMOVE_TAG,
           |  UPDATE_FIELD_EDITOR
           |} from '../constants/actionTypes';
+          |
           |import ListErrors from './ListErrors';
         `);
       },
@@ -3108,11 +3127,6 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |/* Core */
           |
-          |/* Supporting */
-          |// Note that importing \`gql\` by itself, then destructuring
-          |// additional properties separately before exporting, is intentional...
-          |import gql from 'graphql-tag';
-          |
           |export {
           |  ApolloClient,
           |  ApolloClientOptions,
@@ -3196,13 +3210,17 @@ const baseTests = (expect) => ({
           |  ObservableSubscription,
           |  Observer} from '../utilities/observables/Observable';
           |
+          |/* Supporting */
+          |
+          |// Note that importing \`gql\` by itself, then destructuring
+          |// additional properties separately before exporting, is intentional...
+          |import gql from 'graphql-tag';
           |export const {
           |  resetCaches,
           |  disableFragmentWarnings,
           |  enableExperimentalFragmentVariables,
           |  disableExperimentalFragmentVariables
           |} = gql;
-          |
           |export { gql };
         `);
       },
@@ -3539,15 +3557,14 @@ const flowTests = {
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |export type {X} from "X";
           |export type {Z} from "Z";
+          |export type Y = 5;
+          |export type {X} from "X";
           |
           |export type {E} from "@/B";
           |export type {C} from "/B";
           |
           |export type {B} from "./B";
-          |
-          |export type Y = 5;
         `);
       },
       errors: 1,
@@ -3633,6 +3650,7 @@ const flowTests = {
           |import type { ObjMap } from '../jsutils/ObjMap';
           |import promiseForObject from '../jsutils/promiseForObject';
           |import promiseReduce from '../jsutils/promiseReduce';
+          |
           |import type {
           |  DocumentNode,
           |  FieldNode,
@@ -3642,7 +3660,9 @@ const flowTests = {
           |  OperationDefinitionNode,
           |  SelectionSetNode,
           |} from '../language/ast';
+          |
           |import { Kind } from '../language/kinds';
+          |
           |import type {
           |  GraphQLAbstractType,
           |  GraphQLField,
@@ -3654,6 +3674,7 @@ const flowTests = {
           |  GraphQLResolveInfo,
           |  ResponsePath,
           |} from '../type/definition';
+          |
           |import {
           |  isAbstractType,
           |  isLeafType,
@@ -3661,19 +3682,23 @@ const flowTests = {
           |  isNonNullType,
           |  isObjectType,
           |} from '../type/definition';
+          |
           |import {
           |  GraphQLIncludeDirective,
           |  GraphQLSkipDirective,
           |} from '../type/directives';
+          |
           |import {
           |  SchemaMetaFieldDef,
           |  TypeMetaFieldDef,
           |  TypeNameMetaFieldDef,
           |} from '../type/introspection';
+          |
           |import type { GraphQLSchema } from '../type/schema';
           |import { assertValidSchema } from '../type/validate';
           |import { getOperationRootType } from '../utilities/getOperationRootType';
           |import { typeFromAST } from '../utilities/typeFromAST';
+          |
           |import {
           |  getArgumentValues,
           |  getDirectiveValues,
@@ -4011,15 +4036,14 @@ const typescriptTests = {
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
-          |export type {X} from "X";
           |export type {Z} from "Z";
+          |export type Y = 5;
+          |export type {X} from "X";
           |
           |export type {E} from "@/B";
           |export type {C} from "/B";
           |
           |export type {B} from "./B";
-          |
-          |export type Y = 5;
         `);
       },
       errors: 1,
@@ -4073,10 +4097,12 @@ const typescriptTests = {
           |import { isNonEmptyArray } from '../utilities/common/arrays';
           |import { graphQLResultHasError } from '../utilities/common/errorHandling';
           |import { ObservableSubscription } from '../utilities/observables/Observable';
+          |
           |import {
           |  isNetworkRequestInFlight,
           |  NetworkStatus,
           |} from './networkStatus';
+          |
           |import { ObservableQuery } from './ObservableQuery';
           |import { QueryListener } from './types';
           |import { WatchQueryOptions } from './watchQueryOptions';

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1809,7 +1809,7 @@ const baseTests = (expect) => ({
           |*/
           |
           |require("c"); import x7 from "b"; import x8 from "a"; export {x9}; require("c")
-          |var x8
+          |var x9
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -2243,27 +2243,24 @@ const baseTests = (expect) => ({
       code: input`
           |// before
           |/* also
-          |before */  {b} from "b";
-          |import a from "a"; /*a*/ /* comment
+          |before */ export /*middle*/ {b,a}; /* comment
           |after */ // after
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |// before
           |/* also
-          |before */ import a from "a"; /*a*/ 
-          |
-          |export {b} from "b";/* comment
+          |before */ export /*middle*/ {a,b}; /* comment
           |after */ // after
         `);
       },
       errors: [
         {
-          messageId: "both",
+          messageId: "exports",
           line: 3,
           column: 11,
-          endLine: 4,
-          endColumn: 26,
+          endLine: 3,
+          endColumn: 34,
         },
       ],
     },
@@ -2601,8 +2598,8 @@ const baseTests = (expect) => ({
           |    a: 1,
           |
           |    b: 2
-          |    }"specifiers-empty"
-          |export {a} from "a"
+          |    }, a = 1
+          |export {options, a}
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -2973,6 +2970,24 @@ const baseTests = (expect) => ({
     // https://github.com/facebook/react/blob/4c7036e807fa18a3e21a5182983c7c0f05c5936e/packages/react-dom/src/client/ReactDOM.js#L193-L217
     {
       code: input`
+          |var
+          |  createPortal,
+          |  batchedUpdates,
+          |  flushSync,
+          |  Internals,
+          |  ReactVersion,
+          |  findDOMNode,
+          |  hydrate,
+          |  render,
+          |  unmountComponentAtNode,
+          |  createRoot,
+          |  createBlockingRoot,
+          |  flushControlled,
+          |  scheduleHydration,
+          |  renderSubtreeIntoContainer,
+          |  unstable_createPortal,
+          |  createEventHandle
+          |;
           |export {
           |  createPortal,
           |  batchedUpdates as unstable_batchedUpdates,
@@ -3456,7 +3471,7 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot();
       },
-      errors: 1,
+      errors: 3,
     },
   ],
 });

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -3303,8 +3303,12 @@ const baseTests = (expect) => ({
           |  }
           |}
           |export var v1 = 1
+          |
           |export let v2 = 2, v2_2 = 22
-          |export const v3 = 3
+          |
+          |
+          |  // Three!
+          |export const v3 = 3; /*middle*/ export const v3_2 = 33
           |export const { name1, name2: renamed } = someObject
           |import x0 from "a"
           |import "style.css";

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -196,6 +196,19 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {x2} from "b"
+          |export {x1} from "a";
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {x1} from "a";
+          |export {x2} from "b"
+        `);
+      },
+      errors: 1,
+    },
 
     // Semicolon-free code style, with start-of-line guarding semicolon.
     {
@@ -209,6 +222,23 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |import x1 from "a"
           |import x2 from "b"
+          |
+          |;[].forEach()
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {x2} from "b"
+          |export {x1} from "a"
+          |
+          |;[].forEach()
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {x1} from "a"
+          |export {x2} from "b"
           |
           |;[].forEach()
         `);
@@ -230,6 +260,28 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |import a from "a"
           |import { foo } from "bar"
+          |
+          |;(async function() {
+          |  await foo()
+          |})()
+        `);
+      },
+      errors: 1,
+      parserOptions: { ecmaVersion: 2018 },
+    },
+    {
+      code: input`
+          |export { foo } from "bar"
+          |export {a} from "a"
+          |
+          |;(async function() {
+          |  await foo()
+          |})()
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from "a"
+          |export { foo } from "bar"
           |
           |;(async function() {
           |  await foo()
@@ -264,6 +316,29 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {x2} from "b"
+          |export {x7} from "g";
+          |export {x6} from "f"
+          |;export {x5} from "e"
+          |export {x4} from "d" ; export {x3} from "c"
+          |export {x1} from "a" ; [].forEach()
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {x1} from "a" ; 
+          |export {x2} from "b"
+          |export {x3} from "c"
+          |export {x4} from "d" ; 
+          |export {x5} from "e"
+          |export {x6} from "f"
+          |;
+          |export {x7} from "g";[].forEach()
+        `);
+      },
+      errors: 1,
+    },
 
     // Comments around start-of-line guarding semicolon.
     {
@@ -277,6 +352,23 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |import x1 from "a" // a
           |import x2 from "b"
+          |
+          |;/* comment */[].forEach()
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {x2} from "b"
+          |export {x1} from "a" // a
+          |
+          |;/* comment */[].forEach()
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {x1} from "a" // a
+          |export {x2} from "b"
           |
           |;/* comment */[].forEach()
         `);
@@ -301,6 +393,22 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {x2} from "b"
+          |export {x1} from "a"
+          |
+          |;
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {x1} from "a"
+          |;
+          |export {x2} from "b"
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers.
     {
@@ -309,6 +417,22 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(
           `import { a as c,b, e } from "specifiers"`
         );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { e, b, a as c } from "specifiers"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a as c,b, e } from "specifiers"`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { e, b, a as c }`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export { a as c,b, e }`);
       },
       errors: 1,
     },
@@ -334,6 +458,15 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: `export { e, b, a as c, } from "specifiers-trailing-comma"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a as c,b, e,  } from "specifiers-trailing-comma"`
+        );
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with renames.
     {
@@ -341,6 +474,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `import { a,a as b2, a as c, b } from "specifiers-renames"`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { a as c, a as b2, b, a } from "specifiers-renames"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a,a as b2, a as c, b } from "specifiers-renames"`
         );
       },
       errors: 1,
@@ -400,6 +542,59 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  B,
+          |  a,
+          |  A,
+          |  b,
+          |  B2,
+          |  bb,
+          |  BB,
+          |  bB,
+          |  Bb,
+          |  ab,
+          |  ba,
+          |  Ba,
+          |  BA,
+          |  bA,
+          |  x as d,
+          |  x as C,
+          |  img10,
+          |  img2,
+          |  img1,
+          |  img10_black,
+          |} from "specifiers-human-sort"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  A,
+          |  a,
+          |  ab,
+          |  B,
+          |  b,
+          |  B2,
+          |  BA,
+          |  Ba,
+          |  bA,
+          |  ba,
+          |  BB,
+          |  Bb,
+          |  bB,
+          |  bb,
+          |  img1,
+          |  img2,
+          |  img10,
+          |  img10_black,
+          |  x as C,
+          |  x as d,
+          |} from "specifiers-human-sort"
+        `);
+      },
+      errors: 1,
+    },
 
     // Keyword-like specifiers.
     {
@@ -407,6 +602,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `import { aaNotKeyword, abstract, any, as, asserts, async, /*await,*/ bigint, boolean, constructor, declare, from, get, global, infer, is, keyof, module, namespace, never, number, object, of,readonly, require, set, string, symbol, type, undefined, unique, unknown, zzNotKeyword } from 'keyword-identifiers';`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { aaNotKeyword, zzNotKeyword, abstract, as, asserts, any, async, /*await,*/ boolean, constructor, declare, get, infer, is, keyof, module, namespace, never, readonly, require, number, object, set, string, symbol, type, undefined, unique, unknown, from, global, bigint, of } from 'keyword-identifiers';`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { aaNotKeyword, abstract, any, as, asserts, async, /*await,*/ bigint, boolean, constructor, declare, from, get, global, infer, is, keyof, module, namespace, never, number, object, of,readonly, require, set, string, symbol, type, undefined, unique, unknown, zzNotKeyword } from 'keyword-identifiers';`
         );
       },
       errors: 1,
@@ -422,6 +626,15 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: `export {e,b,a as c} from "specifiers-no-spaces"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export {a as c,b,e} from "specifiers-no-spaces"`
+        );
+      },
+      errors: 1,
+    },
 
     // Space before specifiers.
     {
@@ -429,6 +642,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `import { a,b} from "specifiers-no-space-before"`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { b,a} from "specifiers-no-space-before"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a,b} from "specifiers-no-space-before"`
         );
       },
       errors: 1,
@@ -444,6 +666,15 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: `export {b,a } from "specifiers-no-space-after"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export {a,b } from "specifiers-no-space-after"`
+        );
+      },
+      errors: 1,
+    },
 
     // Space after specifiers.
     {
@@ -451,6 +682,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `import {a,b, } from "specifiers-no-space-after-trailing"`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export {b,a, } from "specifiers-no-space-after-trailing"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export {a,b, } from "specifiers-no-space-after-trailing"`
         );
       },
       errors: 1,
@@ -470,6 +710,29 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |import {
+          |  a,
+          |  b, // b
+          |  // c
+          |  c
+          |  // last
+          |} from "specifiers-comments"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |  // c
+          |  c,
+          |  b, // b
+          |  a
+          |  // last
+          |} from "specifiers-comments"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
           |  a,
           |  b, // b
           |  // c
@@ -504,6 +767,28 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  // c
+          |  c,b, // b
+          |  a
+          |  // last
+          |} from "specifiers-comments-last"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,
+          |b, // b
+          |  // c
+          |  c
+          |  // last
+          |} from "specifiers-comments-last"
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with comment between.
     {
@@ -511,6 +796,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `import { a,b /* b */ } from "specifiers-comment-between"`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { b /* b */, a } from "specifiers-comment-between"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a,b /* b */ } from "specifiers-comment-between"`
         );
       },
       errors: 1,
@@ -529,6 +823,27 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |import {
+          |  a,
+          |  c,
+          |  // x
+          |  // y
+          |} from "specifiers-trailing"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |  c,
+          |  a,
+          |  // x
+          |  // y
+          |} from "specifiers-trailing"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
           |  a,
           |  c,
           |  // x
@@ -564,6 +879,30 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  /*c1*/ c, /*c2*/ /*a1
+          |  */a, /*a2*/ /*
+          |  after */
+          |  // x
+          |  // y
+          |} from "specifiers-multiline-comments"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |/*a1
+          |  */a, /*a2*/ 
+          |  /*c1*/ c, /*c2*/ /*
+          |  after */
+          |  // x
+          |  // y
+          |} from "specifiers-multiline-comments"
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with multiline end comment.
     {
@@ -577,6 +916,24 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |import {
+          |  a,   b/*
+          |  after */
+          |} from "specifiers-multiline-end-comment"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |  b,
+          |  a /*
+          |  after */
+          |} from "specifiers-multiline-end-comment"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
           |  a,   b/*
           |  after */
           |} from "specifiers-multiline-end-comment"
@@ -606,6 +963,26 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  b,
+          |  a /*a*/
+          |  /*
+          |  after */
+          |} from "specifiers-multiline-end-comment-after-newline"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a, /*a*/
+          |  b  /*
+          |  after */
+          |} from "specifiers-multiline-end-comment-after-newline"
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with multiline end comment and no newline.
     {
@@ -624,6 +1001,22 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |  b,
+          |  a /*
+          |  after */ } from "specifiers-multiline-end-comment-no-newline"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,   b/*
+          |  after */ } from "specifiers-multiline-end-comment-no-newline"
+        `);
+      },
+      errors: 1,
+    },
 
     // Sorting specifiers with lots of comments.
     {
@@ -631,6 +1024,15 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(
           `/*1*//*2*/import/*3*/def,/*4*/{/*{*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/b/*b1*/,/*b2*/e/*e1*/,/*e2*//*e3*/}/*5*/from/*6*/"specifiers-lots-of-comments"/*7*//*8*/`
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `/*1*//*2*/export/*3*//*4*/{/*{*/e/*e1*/,/*e2*//*e3*/b/*b1*/,/*b2*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/}/*5*/from/*6*/"specifiers-lots-of-comments"/*7*//*8*/`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `/*1*//*2*/export/*3*//*4*/{/*{*/a/*a1*/as/*a2*/c/*a3*/,/*a4*/b/*b1*/,/*b2*/e/*e1*/,/*e2*//*e3*/}/*5*/from/*6*/"specifiers-lots-of-comments"/*7*//*8*/`
         );
       },
       errors: 1,
@@ -675,6 +1077,44 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export { // start
+          |  /* c1 */ c /* c2 */, // c3
+          |  // b1
+          |
+          |  b as /* b2 */ renamed
+          |  , /* b3 */ /* a1
+          |  */ a /* not-a
+          |  */ // comment at end
+          |} from "specifiers-lots-of-comments-multiline";
+          |export {
+          |  e,
+          |  d, /* d */ /* not-d
+          |  */ // comment at end after trailing comma
+          |} from "specifiers-lots-of-comments-multiline-2";
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export { // start
+          |/* a1
+          |  */ a, 
+          |  // b1
+          |  b as /* b2 */ renamed
+          |  , /* b3 */ 
+          |  /* c1 */ c /* c2 */// c3
+          |/* not-a
+          |  */ // comment at end
+          |} from "specifiers-lots-of-comments-multiline";
+          |export {
+          |  d, /* d */   e,
+          |/* not-d
+          |  */ // comment at end after trailing comma
+          |} from "specifiers-lots-of-comments-multiline-2";
+        `);
+      },
+      errors: 1,
+    },
 
     // No empty line after last specifier due to newline before comma.
     {
@@ -688,6 +1128,24 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |import {
+          |  a,
+          |  b/*b*/
+          |  } from "specifiers-blank";
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |  b/*b*/
+          |  ,
+          |  a
+          |} from "specifiers-blank";
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
           |  a,
           |  b/*b*/
           |  } from "specifiers-blank";
@@ -724,6 +1182,33 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {z, y,
+          |  x,
+          |
+          |w,
+          |    v
+          |  as /*v*/
+          |
+          |    u , t /*t*/, // t
+          |    s
+          |} from "specifiers-inline-multiline"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {    s,
+          |t /*t*/, // t
+          |    v
+          |  as /*v*/
+          |    u , w,
+          |  x,
+          |y,
+          |z} from "specifiers-inline-multiline"
+        `);
+      },
+      errors: 1,
+    },
 
     // Indent: 0.
     {
@@ -736,6 +1221,23 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |import {
+          |a,
+          |b,
+          |} from "specifiers-indent-0"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |b,
+          |a,
+          |} from "specifiers-indent-0"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
           |a,
           |b,
           |} from "specifiers-indent-0"
@@ -762,6 +1264,23 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |    b,
+          |    a,
+          |} from "specifiers-indent-4"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |    a,
+          |    b,
+          |} from "specifiers-indent-4"
+        `);
+      },
+      errors: 1,
+    },
 
     // Indent: tab.
     {
@@ -774,6 +1293,23 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |import {
+          |→a,
+          |→b,
+          |} from "specifiers-indent-tab"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |\tb,
+          |\ta,
+          |} from "specifiers-indent-tab"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
           |→a,
           |→b,
           |} from "specifiers-indent-tab"
@@ -805,17 +1341,43 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          | //
+          |\tb,
+          |  a,
+          |
+          |    c,
+          |} from "specifiers-indent-mixed"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |  a,
+          | //
+          |→b,
+          |    c,
+          |} from "specifiers-indent-mixed"
+        `);
+      },
+      errors: 1,
+    },
 
     // Several chunks.
     {
       code: input`
           |require("c");
           |
+          |export {x3} from "a"
           |import x1 from "b"
           |import x2 from "a"
+          |export {x4} from "c"
           |require("c");
           |
           |import x3 from "b"
+          |export default 5
+          |export const answer = 42
           |import x4 from "a" // x4
           |
           |// c1
@@ -825,7 +1387,7 @@ const baseTests = (expect) => ({
           |import x6 from "a" /* after
           |*/
           |
-          |require("c"); import x7 from "b"; import x8 from "a"; require("c")
+          |require("c"); import x7 from "b"; import x8 from "a"; export {x9}; require("c")
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
@@ -833,10 +1395,16 @@ const baseTests = (expect) => ({
           |
           |import x2 from "a"
           |import x1 from "b"
+          |
+          |export {x3} from "a"
+          |export {x4} from "c"
           |require("c");
           |
           |import x4 from "a" // x4
           |import x3 from "b"
+          |
+          |export default 5
+          |export const answer = 42
           |
           |// c1
           |require("c");
@@ -846,13 +1414,14 @@ const baseTests = (expect) => ({
           |*/
           |
           |require("c"); import x8 from "a"; 
-          |import x7 from "b"; require("c")
+          |import x7 from "b";
+          |export {x8}; require("c")
         `);
       },
       errors: 4,
     },
 
-    // Original order is preserved for duplicate imports.
+    // Original order is preserved for duplicate imports/exports.
     {
       code: input`
           |import b from "b"
@@ -868,8 +1437,23 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {b} from "b"
+          |export {a1} from "a"
+          |export {a2} from "a"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a1} from "a"
+          |export {a2} from "a"
+          |export {b} from "b"
+        `);
+      },
+      errors: 1,
+    },
 
-    // Original order is preserved for duplicate imports (reversed example).
+    // Original order is preserved for duplicate imports/exports (reversed example).
     {
       code: input`
           |import b from "b"
@@ -881,6 +1465,21 @@ const baseTests = (expect) => ({
           |import {a2} from "a"
           |import a1 from "a"
           |import b from "b"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {b} from "b"
+          |export {a2} from "a"
+          |export {a1} from "a"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a2} from "a"
+          |export {a1} from "a"
+          |export {b} from "b"
         `);
       },
       errors: 1,
@@ -1032,6 +1631,37 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |// before
+          |
+          |/* also
+          |before */ /* b */ export {b} from "b" // b
+          |// above d
+          |  export {d} /*d1*/ from   "d" ; /* d2 */ /* before
+          |  c0 */ // before c1
+          |  /* c0
+          |*/ /*c1*/ /*c2*/export {c} from 'c' ; /*c3*/ export {a} from "a" /*a*/ /*
+          |   x1 */ /* x2 */
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |// before
+          |
+          |/* also
+          |before */ export {a} from "a" /*a*/ 
+          |/* b */ export {b} from "b" // b
+          |/* before
+          |  c0 */ // before c1
+          |  /* c0
+          |*/ /*c1*/ /*c2*/export {c} from 'c' ; /*c3*/ 
+          |// above d
+          |  export {d} /*d1*/ from   "d" ; /* d2 */ /*
+          |   x1 */ /* x2 */
+        `);
+      },
+      errors: 1,
+    },
 
     // Line comment and code after.
     {
@@ -1043,6 +1673,20 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |import a from "a"; 
           |import b from "b"; // b
+          |code();
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {b} from "b"; // b
+          |export {a} from "a"; code();
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from "a"; 
+          |export {b} from "b"; // b
           |code();
         `);
       },
@@ -1066,6 +1710,22 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {b} from "b"; // b
+          |export {a} from "a"; /*
+          |after */
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from "a"; 
+          |export {b} from "b"; // b
+          |/*
+          |after */
+        `);
+      },
+      errors: 1,
+    },
 
     // Line comment but _singleline_ block comment after.
     {
@@ -1077,6 +1737,19 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(`
           |import a from "a"; /* a */
           |import b from "b"; // b
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {b} from "b"; // b
+          |export {a} from "a"; /* a */
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from "a"; /* a */
+          |export {b} from "b"; // b
         `);
       },
       errors: 1,
@@ -1190,6 +1863,29 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {c} from "c"
+          |// b1
+          |
+          |// b2
+          |export {b} from "b"
+          |// a
+          |
+          |export {a} from "a"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |// a
+          |export {a} from "a"
+          |// b1
+          |// b2
+          |export {b} from "b"
+          |export {c} from "c"
+        `);
+      },
+      errors: 1,
+    },
 
     // Collapse blank lines between comments – CR.
     {
@@ -1217,8 +1913,33 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {c} from "c"\r
+          |// b1\r
+          |\r
+          |// b2\r
+          |export {b} from "b"\r
+          |// a\r
+          |\r
+          |export {a} from "a"\r
+          |after();\r
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |// a<CR>
+          |export {a} from "a"<CR>
+          |// b1<CR>
+          |// b2<CR>
+          |export {b} from "b"<CR>
+          |export {c} from "c"<CR>
+          |after();<CR>
+        `);
+      },
+      errors: 1,
+    },
 
-    // Collapse blank lines inside import statements.
+    // Collapse blank lines inside import/export statements.
     {
       code: input`
           |import
@@ -1283,6 +2004,98 @@ const baseTests = (expect) => ({
           |// import
           |def /* default */
           |,
+          |// default
+          | {
+          |  // a1
+          |  // a2
+          |  a
+          |  // a3
+          |  as
+          |  // a4
+          |  d
+          |  // a5
+          |  , // a6
+          |  /* b
+          |   */
+          |  b // b
+          |  ,
+          |  // c
+          |  c /*c*/,
+          |  // last
+          |}
+          |// from1
+          |from
+          |// from2
+          |"c"
+          |// final
+          |;
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export
+          |
+          |// export
+          |
+          |/* default */
+          |
+          |
+          |
+          |// default
+          |
+          | {
+          |
+          |  // c
+          |
+          |  c /*c*/,
+          |
+          |  /* b
+          |   */
+          |
+          |  b // b
+          |  ,
+          |
+          |  // a1
+          |
+          |  // a2
+          |
+          |  a
+          |
+          |  // a3
+          |
+          |  as
+          |
+          |  // a4
+          |
+          |  d
+          |
+          |  // a5
+          |
+          |  , // a6
+          |
+          |  // last
+          |
+          |}
+          |
+          |// from1
+          |
+          |from
+          |
+          |// from2
+          |
+          |"c"
+          |
+          |// final
+          |
+          |;
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export
+          |// export
+          |/* default */
           |// default
           | {
           |  // a1
@@ -1328,6 +2141,46 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |export {
+          |
+          |    } from "specifiers-empty"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
+          |    } from "specifiers-empty"
+        `);
+      },
+      errors: 1,
+    },
+
+    // Do not collapse empty lines inside export code.
+    {
+      code: input`
+          |export const options = {
+          |
+          |    a: 1,
+          |
+          |    b: 2
+          |    }"specifiers-empty"
+          |export {a} from "a"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from "a"
+          |
+          |export const options = {
+          |
+          |    a: 1,
+          |
+          |    b: 2
+          |    }"specifiers-empty"
+        `);
+      },
+      errors: 1,
+    },
 
     // Single-line comment at the end of the last specifier should not comment
     // out the `from` part.
@@ -1341,6 +2194,22 @@ const baseTests = (expect) => ({
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
           |import {
+          |a,  b // b
+          |  } from "specifiers-line-comment"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {
+          |
+          |  b // b
+          |  ,a} from "specifiers-line-comment"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {
           |a,  b // b
           |  } from "specifiers-line-comment"
         `);
@@ -1374,6 +2243,35 @@ const baseTests = (expect) => ({
           |    // d
           |    import d from "d"
           |  import e from "e"
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |  export {e} from "e"
+          |  // b
+          |  export {
+          |    b4, b3,
+          |    b2
+          |  } from "b";
+          |  /* a */ export {a} from "a"; export {c} from "c"
+          |  
+          |    // d
+          |    export {d} from "d"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |  /* a */ export {a} from "a"; 
+          |  // b
+          |  export {
+          |    b2,
+          |b3,
+          |    b4  } from "b";
+          |export {c} from "c"
+          |    // d
+          |    export {d} from "d"
+          |  export {e} from "e"
         `);
       },
       errors: 1,
@@ -1413,6 +2311,39 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      code: input`
+          |      \r
+          |  export {e} from "e"\r
+          |  // b\r
+          |  export {\r
+          |    b4, b3,\r
+          |    b2\r
+          |  } from "b";\r
+          |  /* a */ export {a} from "a"; export {c} from "c"\r
+          | \r
+          |    // d\r
+          |    export {d} from "d"\r
+          |
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |      <CR>
+          |  /* a */ export {a} from "a"; <CR>
+          |  // b<CR>
+          |  export {<CR>
+          |    b2,<CR>
+          |b3,<CR>
+          |    b4  } from "b";<CR>
+          |export {c} from "c"<CR>
+          |    // d<CR>
+          |    export {d} from "d"<CR>
+          |  export {e} from "e"<CR>
+          |
+        `);
+      },
+      errors: 1,
+    },
 
     // Trailing spaces.
     {
@@ -1436,6 +2367,32 @@ const baseTests = (expect) => ({
           |import e from "e"; 
           |/* multiline
           |comment 2 */ import f from "f";
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export {c} from "c";  /* comment */  
+          |export {b} from "b";    
+          |export {d} from "d";  /* multiline
+          |comment */  
+          |export {a} from "a"    
+          |export {e}; /* multiline
+          |comment 2 */ export {f} from "f";
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |/* multiline
+          |comment */  
+          |export {a} from "a"    
+          |export {b} from "b";    
+          |export {c} from "c";  /* comment */  
+          |export {d} from "d";  
+          |
+          |export {e}; 
+          |/* multiline
+          |comment 2 */ export {f} from "f";
         `);
       },
       errors: 1,
@@ -1731,6 +2688,21 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      options: [{ groups: [["^\\p{L}"], ["^\\."]] }],
+      code: input`
+          |export {b} from '.';
+          |export {a} from 'ä';
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from 'ä';
+          |
+          |export {b} from '.';
+        `);
+      },
+      errors: 1,
+    },
 
     // `groups` – non-matching imports end up last.
     {
@@ -1753,6 +2725,29 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+    {
+      options: [{ groups: [["^\\w"], ["^\\."]] }],
+      code: input`
+          |export {c} from '';
+          |export {e}
+          |export {b} from '.';
+          |export {a} from 'a';
+          |export {d} from '@/a';
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from 'a';
+          |
+          |export {b} from '.';
+          |
+          |export {c} from '';
+          |export {d} from '@/a';
+          |
+          |export {e}
+        `);
+      },
+      errors: 1,
+    },
 
     // `groups` – first longest match wins.
     {
@@ -1769,6 +2764,24 @@ const baseTests = (expect) => ({
           |import b from 'bx';
           |
           |import c from './';
+        `);
+      },
+      errors: 1,
+    },
+    {
+      options: [{ groups: [["^\\w"], ["^\\w{2}"], ["^.{2}"]] }],
+      code: input`
+          |export {c} from './';
+          |export {b} from 'bx';
+          |export {a} from 'a';
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export {a} from 'a';
+          |
+          |export {b} from 'bx';
+          |
+          |export {c} from './';
         `);
       },
       errors: 1,
@@ -1931,6 +2944,32 @@ const flowTests = {
           |import type B from "./B";
           |import typeof D from "./D";
           |import {type Y, typeof T, pluralize,truncate} from "./utils"
+        `);
+      },
+      errors: 1,
+    },
+
+    // Type exports.
+    {
+      code: input`
+          |export type {Z} from "Z";
+          |export type Y = 5;
+          |export type {X} from "X";
+          |export type {B} from "./B";
+          |export type {C} from "/B";
+          |export type {E} from "@/B";
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export type {X} from "X";
+          |export type {Z} from "Z";
+          |
+          |export type {E} from "@/B";
+          |export type {C} from "/B";
+          |
+          |export type {B} from "./B";
+          |
+          |export type Y = 5;
         `);
       },
       errors: 1,
@@ -2260,6 +3299,32 @@ const typescriptTests = {
           |function pluck<T, K extends keyof T>(o: T, names: K[]): T[K][] {
           |  return names.map(n => o[n]);
           |}
+        `);
+      },
+      errors: 1,
+    },
+
+    // Type exports.
+    {
+      code: input`
+          |export type {Z} from "Z";
+          |export type Y = 5;
+          |export type {X} from "X";
+          |export type {B} from "./B";
+          |export type {C} from "/B";
+          |export type {E} from "@/B";
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export type {X} from "X";
+          |export type {Z} from "Z";
+          |
+          |export type {E} from "@/B";
+          |export type {C} from "/B";
+          |
+          |export type {B} from "./B";
+          |
+          |export type Y = 5;
         `);
       },
       errors: 1,

--- a/test/sort.test.js
+++ b/test/sort.test.js
@@ -1847,64 +1847,44 @@ const baseTests = (expect) => ({
     },
 
     // Several chunks.
-    // TODOx: Make this a really good test case and fix it.
-    // {
-    //   code: input`
-    //       |require("c");
-    //       |
-    //       |export {x3} from "a"
-    //       |import i1 from "b"
-    //       |import i2 from "a"
-    //       |export {x4} from "c"
-    //       |require("c");
-    //       |
-    //       |import i3 from "b"
-    //       |export default 5
-    //       |export const answer = 42
-    //       |import i4 from "a" // x4
-    //       |
-    //       |// c1
-    //       |require("c");
-    //       |import i5 from "b"
-    //       |// x6-1
-    //       |import i6 from "a" /* after
-    //       |*/
-    //       |
-    //       |require("c"); import i7 from "b"; import i8 from "a"; export {x9}; require("c")
-    //       |var x9
-    //   `,
-    //   output: (actual) => {
-    //     expect(actual).toMatchInlineSnapshot(`
-    //       |require("c");
-    //       |
-    //       |import x2 from "a"
-    //       |import x1 from "b"
-    //       |
-    //       |export {x3} from "a"
-    //       |export {x4} from "c"
-    //       |require("c");
-    //       |
-    //       |import x4 from "a" // x4
-    //       |import x3 from "b"
-    //       |
-    //       |export default 5
-    //       |export const answer = 42
-    //       |
-    //       |// c1
-    //       |require("c");
-    //       |// x6-1
-    //       |import x6 from "a"
-    //       |import x5 from "b"/* after
-    //       |*/
-    //       |
-    //       |require("c"); import x8 from "a";
-    //       |import x7 from "b";
-    //       |export {x8}; require("c")
-    //       |var x8
-    //     `);
-    //   },
-    //   errors: 4,
-    // },
+    {
+      code: input`
+          |require("c");
+          |
+          |import i1 from "b"
+          |import i2 from "a"
+          |export {x1} from "c"
+          |export {x2} from "a"
+          |
+          |import i3 from "b"
+          |export default 5
+          |export const answer = 42
+          |
+          |require("c"); import i4 from "b"; import i5 from "a";
+          |export {x4,x3}; require("c")
+          |var x4, x3
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |require("c");
+          |
+          |import i2 from "a"
+          |import i1 from "b"
+          |export {x2} from "a"
+          |export {x1} from "c"
+          |
+          |import i3 from "b"
+          |export default 5
+          |export const answer = 42
+          |
+          |require("c"); import i5 from "a";
+          |import i4 from "b"; 
+          |export {x3,x4}; require("c")
+          |var x4, x3
+        `);
+      },
+      errors: 4,
+    },
 
     // Original order is preserved for duplicate imports/exports.
     {
@@ -2245,7 +2225,6 @@ const baseTests = (expect) => ({
     },
 
     // Test messageId, lines and columns.
-    // TODOx: Check through if lines/cols actually are reasonable here.
     {
       code: input`
           |// before


### PR DESCRIPTION
Closes https://github.com/lydell/eslint-plugin-simple-import-sort/issues/21.
Supersedes https://github.com/lydell/eslint-plugin-simple-import-sort/pull/43.

- Chunks of imports and chunks of re-exports are sorted separately.
- Other types of exports than `export ... from` are _not_ touched in any way.
- Specifiers of `export {a, b, c}` are still sorted though.
- Re-exports with a comment above also get a blank line above, to allow logical grouping manually.