### PR TITLE
Put `node:*` modules in a separate group by default

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018, 2019, 2020 Simon Lydell
+Copyright (c) 2018, 2019, 2020, 2022 Simon Lydell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -158,9 +158,10 @@ First, the plugin finds all _chunks_ of imports. A “chunk” is a sequence of 
 Then, each chunk is _grouped_ into sections with a blank line between each.
 
 1. `import "./setup"`: Side effect imports. (These are not sorted internally.)
-2. `import react from "react"`: Packages (npm packages and Node.js builtins).
-3. `import a from "/a"`: Absolute imports and other imports such as Vue-style `@/foo`.
-4. `import a from "./a"`: Relative imports.
+2. `import * as fs from "node:fs"`: Node.js builtin modules prefixed with `node:`.
+3. `import react from "react"`: Packages (npm packages and Node.js builtins _without_ `node:`).
+4. `import a from "/a"`: Absolute imports and other imports such as Vue-style `@/foo`.
+5. `import a from "./a"`: Relative imports.
 
 Note: The above groups are very loosely defined. See [Custom grouping] for more information.
 
@@ -227,10 +228,13 @@ import "./setup";
 import "some-polyfill";
 import "./global.css";
 
+// Node.js builtins prefixed with `node:`.
+import * as fs from "node:fs";
+
 // Packages.
 import type A from "an-npm-package";
 import a from "an-npm-package";
-import fs from "fs";
+import fs2 from "fs";
 import b from "https://example.com/script.js";
 
 // Absolute imports and other imports.
@@ -323,7 +327,6 @@ There is **one** option (see [Not for everyone]) called `groups` that allows you
 - Move `src/Button`, `@company/Button` and similar out of the (third party) “packages” group, into their own group.
 - Move `react` first.
 - Remove blank lines between groups.
-- Make a separate group for Node.js builtins.
 - Make a separate group for style imports.
 - Separate `./` and `../` imports.
 - Not use groups at all and only sort alphabetically.
@@ -364,6 +367,8 @@ These are the default groups:
 [
   // Side effect imports.
   ["^\\u0000"],
+  // Node.js builtins prefixed with `node:`.
+  ["^node:"],
   // Packages.
   // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
   ["^@?\\w"],

--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -103,7 +103,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but with no blank lines.
-            groups: [["^\\u0000", "^@?\\w", "^", "^\\."]],
+            groups: [["^\\u0000", "^node:", "^@?\\w", "^", "^\\."]],
           },
         ],
       },
@@ -115,7 +115,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but in reverse.
-            groups: [["^\\."], ["^"], ["^@?\\w"], ["^\\u0000"]],
+            groups: [["^\\."], ["^"], ["^@?\\w"], ["^node:"], ["^\\u0000"]],
           },
         ],
       },
@@ -128,7 +128,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but with type imports first as a separate group.
-            groups: [["^.*\\u0000$"], ["^\\u0000"], ["^@?\\w"], ["^"], ["^\\."]],
+            groups: [["^.*\\u0000$"], ["^\\u0000"], ["^node:"], ["^@?\\w"], ["^"], ["^\\."]],
           },
         ],
       },
@@ -141,7 +141,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but with type imports last as a separate group.
-            groups: [["^\\u0000"], ["^@?\\w"], ["^"], ["^\\."], ["^.+\\u0000$"]],
+            groups: [["^\\u0000"], ["^node:"], ["^@?\\w"], ["^"], ["^\\."], ["^.+\\u0000$"]],
           },
         ],
       },
@@ -156,8 +156,9 @@ module.exports = {
             // The default grouping, but with type imports first as a separate
             // group, sorting that group like non-type imports are grouped.
             groups: [
-              ["^@?\\w.*\\u0000$", "^[^.].*\\u0000$", "^\\..*\\u0000$"],
+              ["^node:.*\\u0000$", "^@?\\w.*\\u0000$", "^[^.].*\\u0000$", "^\\..*\\u0000$"],
               ["^\\u0000"],
+              ["^node:"],
               ["^@?\\w"],
               ["^"],
               ["^\\."],
@@ -177,10 +178,11 @@ module.exports = {
             // group, sorting that group like non-type imports are grouped.
             groups: [
               ["^\\u0000"],
+              ["^node:"],
               ["^@?\\w"],
               ["^"],
               ["^\\."],
-              ["^@?\\w.*\\u0000$", "^[^.].*\\u0000$", "^\\..*\\u0000$"],
+              ["^node:.*\\u0000$", "^@?\\w.*\\u0000$", "^[^.].*\\u0000$", "^\\..*\\u0000$"],
             ],
           },
         ],
@@ -196,6 +198,7 @@ module.exports = {
             // The default grouping, but with type imports first in each group.
             groups: [
               ["^\\u0000"],
+              ["^node:.*\\u0000$", "^node:"],
               ["^@?\\w.*\\u0000$", "^@?\\w"],
               ["(?<=\\u0000)$", "^"],
               ["^\\..*\\u0000$", "^\\."],
@@ -214,6 +217,7 @@ module.exports = {
             // The default grouping, but with type imports last in each group.
             groups: [
               ["^\\u0000"],
+              ["^node:", "^node:.*\\u0000$"],
               ["^@?\\w", "^@?\\w.*\\u0000$"],
               ["(?<!\\u0000)$", "(?<=\\u0000)$"],
               ["^\\.", "^\\..*\\u0000$"],

--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -74,6 +74,8 @@ module.exports = {
             groups: [
               // Node.js builtins. You could also generate this regex if you use a `.js` config.
               // For example: `^(${require("module").builtinModules.join("|")})(/|$)`
+              // Note that if you use the `node:` prefix for Node.js builtins,
+              // you can avoid this complexity: You can simply use "^node:".
               [
                 "^(assert|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|https|module|net|os|path|punycode|querystring|readline|repl|stream|string_decoder|sys|timers|tls|tty|url|util|vm|zlib|freelist|v8|process|async_hooks|http2|perf_hooks)(/.*|$)",
               ],

--- a/examples/groups.default-reverse.js
+++ b/examples/groups.default-reverse.js
@@ -1,4 +1,7 @@
 import "./polyfills";
+import * as fs from "node:fs";
+import fs2 from "fs";
+import forge from "node-forge";
 import react from "react";
 import { storiesOf } from "@storybook/react";
 import App from "@/App";

--- a/examples/groups.none.js
+++ b/examples/groups.none.js
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import react from "react";
 import { storiesOf } from "@storybook/react";
 import App from "@/App";

--- a/examples/groups.type-imports-first-in-each-group.ts
+++ b/examples/groups.type-imports-first-in-each-group.ts
@@ -1,4 +1,8 @@
 import "./polyfills";
+import fs from "node:fs";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import * as path from "node:path";
 import react from "react";
 import type { Component } from "react";
 import type { Store } from "redux";

--- a/examples/groups.type-imports-first-sorted.ts
+++ b/examples/groups.type-imports-first-sorted.ts
@@ -1,4 +1,8 @@
 import "./polyfills";
+import fs from "node:fs";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import * as path from "node:path";
 import react from "react";
 import type { Component } from "react";
 import type { Store } from "redux";

--- a/examples/groups.type-imports-first.ts
+++ b/examples/groups.type-imports-first.ts
@@ -1,4 +1,8 @@
 import "./polyfills";
+import fs from "node:fs";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import * as path from "node:path";
 import react from "react";
 import type { Component } from "react";
 import type { Store } from "redux";

--- a/examples/groups.type-imports-last-in-each-group.ts
+++ b/examples/groups.type-imports-last-in-each-group.ts
@@ -1,4 +1,8 @@
 import "./polyfills";
+import fs from "node:fs";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import * as path from "node:path";
 import react from "react";
 import type { Component } from "react";
 import type { Store } from "redux";

--- a/examples/groups.type-imports-last-sorted.ts
+++ b/examples/groups.type-imports-last-sorted.ts
@@ -1,4 +1,8 @@
 import "./polyfills";
+import fs from "node:fs";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import * as path from "node:path";
 import react from "react";
 import type { Component } from "react";
 import type { Store } from "redux";

--- a/examples/groups.type-imports-last.ts
+++ b/examples/groups.type-imports-last.ts
@@ -1,4 +1,8 @@
 import "./polyfills";
+import fs from "node:fs";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import * as path from "node:path";
 import react from "react";
 import type { Component } from "react";
 import type { Store } from "redux";

--- a/examples/readme-order.prettier.js
+++ b/examples/readme-order.prettier.js
@@ -3,10 +3,13 @@ import "./setup";
 import "some-polyfill";
 import "./global.css";
 
+// Node.js builtins prefixed with `node:`.
+import * as fs from "node:fs";
+
 // Packages.
 import type A from "an-npm-package";
 import a from "an-npm-package";
-import fs from "fs";
+import fs2 from "fs";
 import b from "https://example.com/script.js";
 
 // Absolute imports and other imports.

--- a/src/imports.js
+++ b/src/imports.js
@@ -5,6 +5,8 @@ const shared = require("./shared");
 const defaultGroups = [
   // Side effect imports.
   ["^\\u0000"],
+  // Node.js builtins prefixed with `node:`.
+  ["^node:"],
   // Packages.
   // Things that start with a letter (or digit or underscore), or `@` followed by a letter.
   ["^@?\\w"],

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -141,10 +141,15 @@ import type { Css } from "./styles";
 import type { Config } from "/config";
 import type { AppRouter } from "@/App";
 import type { Story } from "@storybook/react";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
 import type { Component } from "react";
 import type { Store } from "redux";
 
 import "./polyfills";
+
+import fs from "node:fs";
+import * as path from "node:path";
 
 import { storiesOf } from "@storybook/react";
 import react from "react";
@@ -159,6 +164,11 @@ import styles from "./styles";
 
 exports[`examples groups.type-imports-first-in-each-group.ts 1`] = `
 import "./polyfills";
+
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import fs from "node:fs";
+import * as path from "node:path";
 
 import type { Story } from "@storybook/react";
 import type { Component } from "react";
@@ -179,6 +189,8 @@ import styles from "./styles";
 `;
 
 exports[`examples groups.type-imports-first-sorted.ts 1`] = `
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
 import type { Story } from "@storybook/react";
 import type { Component } from "react";
 import type { Store } from "redux";
@@ -188,6 +200,9 @@ import type { Page } from "./page";
 import type { Css } from "./styles";
 
 import "./polyfills";
+
+import fs from "node:fs";
+import * as path from "node:path";
 
 import { storiesOf } from "@storybook/react";
 import react from "react";
@@ -203,6 +218,9 @@ import styles from "./styles";
 exports[`examples groups.type-imports-last.ts 1`] = `
 import "./polyfills";
 
+import fs from "node:fs";
+import * as path from "node:path";
+
 import { storiesOf } from "@storybook/react";
 import react from "react";
 
@@ -217,6 +235,8 @@ import type { Css } from "./styles";
 import type { Config } from "/config";
 import type { AppRouter } from "@/App";
 import type { Story } from "@storybook/react";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
 import type { Component } from "react";
 import type { Store } from "redux";
 
@@ -224,6 +244,11 @@ import type { Store } from "redux";
 
 exports[`examples groups.type-imports-last-in-each-group.ts 1`] = `
 import "./polyfills";
+
+import fs from "node:fs";
+import * as path from "node:path";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
 
 import { storiesOf } from "@storybook/react";
 import react from "react";
@@ -246,6 +271,9 @@ import type { Css } from "./styles";
 exports[`examples groups.type-imports-last-sorted.ts 1`] = `
 import "./polyfills";
 
+import fs from "node:fs";
+import * as path from "node:path";
+
 import { storiesOf } from "@storybook/react";
 import react from "react";
 
@@ -255,6 +283,8 @@ import App from "@/App";
 import page from "./page";
 import styles from "./styles";
 
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
 import type { Story } from "@storybook/react";
 import type { Component } from "react";
 import type { Store } from "redux";

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -439,10 +439,13 @@ import "./setup";
 import "some-polyfill";
 import "./global.css";
 
+// Node.js builtins prefixed with \`node:\`.
+import * as fs from "node:fs";
+
 // Packages.
 import type A from "an-npm-package";
 import a from "an-npm-package";
-import fs from "fs";
+import fs2 from "fs";
 import b from "https://example.com/script.js";
 
 // Absolute imports and other imports.

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -108,7 +108,11 @@ import config from "/config";
 import App from "@/App";
 
 import { storiesOf } from "@storybook/react";
+import fs2 from "fs";
+import forge from "node-forge";
 import react from "react";
+
+import * as fs from "node:fs";
 
 import "./polyfills";
 
@@ -131,6 +135,7 @@ import styles from "./styles";
 import config from "/config";
 import App from "@/App";
 import { storiesOf } from "@storybook/react";
+import * as fs from "node:fs";
 import react from "react";
 
 `;

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -841,6 +841,8 @@ const baseTests = (expect) => ({
           |import {} from "#/test"
           |import {} from "fs";
           |import {} from "fs/something";
+          |import {} from "node:fs/something";
+          |import {} from "node:fs";
           |import {} from "Fs";
           |import {} from "lodash/fp";
           |import {} from "@storybook/react";
@@ -854,6 +856,9 @@ const baseTests = (expect) => ({
       `,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`
+          |import {} from "node:fs";
+          |import {} from "node:fs/something";
+          |
           |import {} from "@storybook/react";
           |import {} from "@storybook/react/something";
           |import {} from "1";


### PR DESCRIPTION
Closes #109. Related to #20.

This puts [`node:` imports](https://nodejs.org/api/esm.html#node-imports) in a separate group by default, above the npm packages group.

I think this makes sense, because the `node:` prefix clearly stands out among npm packages, and it’s a very simple regex (`^node:`), as opposed to supporting all Node.js builtins by name (https://github.com/lydell/eslint-plugin-simple-import-sort/issues/20#issuecomment-557628537) – I think it’s good to keep the default groups simple.