### PR TITLE
Support imports and exports anywhere

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018, 2019, 2020, 2022 Simon Lydell
+Copyright (c) 2018, 2019, 2020, 2022, 2023 Simon Lydell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/shared.js
+++ b/src/shared.js
@@ -2,12 +2,12 @@
 
 // A “chunk” is a sequence of statements of a certain type with only comments
 // and whitespace between.
-function extractChunks(programNode, isPartOfChunk) {
+function extractChunks(parentNode, isPartOfChunk) {
   const chunks = [];
   let chunk = [];
   let lastNode = undefined;
 
-  for (const node of programNode.body) {
+  for (const node of parentNode.body) {
     const result = isPartOfChunk(node, lastNode);
     switch (result) {
       case "PartOfChunk":

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -1106,6 +1106,41 @@ const typescriptTests = {
       },
       errors: 1,
     },
+
+    // Exports inside module declarations.
+    {
+      code: input`
+          |export type {X} from "X";
+          |export type {B} from "./B";
+          |
+          |declare module "a" {
+          |  export type {Z} from "Z";
+          |  export type Y = 5;
+          |  export type {X} from "X";
+          |  export type {B} from "./B";
+          |  export type {C} from "/B";
+          |  export type {E} from "@/B";
+          |  export {a, type type as type, z} from "../type";
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export type {B} from "./B";
+          |export type {X} from "X";
+          |
+          |declare module "a" {
+          |  export type {Z} from "Z";
+          |  export type Y = 5;
+          |  export {type type as type, a, z} from "../type";
+          |  export type {B} from "./B";
+          |  export type {C} from "/B";
+          |  export type {E} from "@/B";
+          |  export type {X} from "X";
+          |}
+        `);
+      },
+      errors: 2,
+    },
   ],
 };
 

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -1113,14 +1113,14 @@ const typescriptTests = {
           |export type {X} from "X";
           |export type {B} from "./B";
           |
-          |declare module "a" {
-          |  export type {Z} from "Z";
-          |  export type Y = 5;
-          |  export type {X} from "X";
-          |  export type {B} from "./B";
-          |  export type {C} from "/B";
-          |  export type {E} from "@/B";
+          |declare module 'my-module' {
+          |  export type { PlatformPath, ParsedPath } from 'path';
+          |  export { type CopyOptions } from 'fs'; interface Something {}
           |  export {a, type type as type, z} from "../type";
+          |  // comment
+          |    export * as d from "d"
+          |export {c} from "c"; /*
+          |  */\texport {} from "b"; // b
           |}
       `,
       output: (actual) => {
@@ -1128,18 +1128,19 @@ const typescriptTests = {
           |export type {B} from "./B";
           |export type {X} from "X";
           |
-          |declare module "a" {
-          |  export type {Z} from "Z";
-          |  export type Y = 5;
+          |declare module 'my-module' {
+          |  export { type CopyOptions } from 'fs'; 
+          |  export type { ParsedPath,PlatformPath } from 'path';interface Something {}
           |  export {type type as type, a, z} from "../type";
-          |  export type {B} from "./B";
-          |  export type {C} from "/B";
-          |  export type {E} from "@/B";
-          |  export type {X} from "X";
+          |  // comment
+          |/*
+          |  */→export {} from "b"; // b
+          |export {c} from "c"; 
+          |    export * as d from "d"
           |}
         `);
       },
-      errors: 2,
+      errors: 4,
     },
   ],
 };

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -2000,6 +2000,31 @@ const typescriptTests = {
       },
       errors: 1,
     },
+
+    // Imports inside module declarations.
+    {
+      code: input`
+          |import type { ParsedPath } from 'path';
+          |import type { CopyOptions } from 'fs';
+          |
+          |declare module 'my-module' {
+          |  import type { ParsedPath } from 'path';
+          |  import type { CopyOptions } from 'fs';
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import type { CopyOptions } from 'fs';
+          |import type { ParsedPath } from 'path';
+          |
+          |declare module 'my-module' {
+          |  import type { CopyOptions } from 'fs';
+          |  import type { ParsedPath } from 'path';
+          |}
+        `);
+      },
+      errors: 2,
+    },
   ],
 };
 

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -2008,8 +2008,13 @@ const typescriptTests = {
           |import type { CopyOptions } from 'fs';
           |
           |declare module 'my-module' {
-          |  import type { ParsedPath } from 'path';
-          |  import type { CopyOptions } from 'fs';
+          |  import type { PlatformPath, ParsedPath } from 'path';
+          |  import { type CopyOptions } from 'fs';
+          |  export function normalize(p: string): string;
+          |  // comment
+          |    import "d"
+          |import c from "c"; /*
+          |  */\timport * as b from "b"; // b
           |}
       `,
       output: (actual) => {
@@ -2018,12 +2023,19 @@ const typescriptTests = {
           |import type { ParsedPath } from 'path';
           |
           |declare module 'my-module' {
-          |  import type { CopyOptions } from 'fs';
-          |  import type { ParsedPath } from 'path';
+          |  import { type CopyOptions } from 'fs';
+          |  import type { ParsedPath,PlatformPath } from 'path';
+          |  export function normalize(p: string): string;
+          |  // comment
+          |    import "d"
+          |
+          |/*
+          |  */→import * as b from "b"; // b
+          |import c from "c"; 
           |}
         `);
       },
-      errors: 2,
+      errors: 3,
     },
   ],
 };


### PR DESCRIPTION
Fixes #121 

In JavaScript, imports and exports can only appear at the top level – in the `Program` node.

In Svelte via eslint-plugin-svelte, the imports and exports are inside the `SvelteScriptElement` node though.

In TypeScript, you can also have imports and exports inside `declare module`.

This PR supports imports and exports _anywhere,_ by finding the set of parents of all imports and exports and working with those.