### PR TITLE
Add recommended config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,18 @@ const importsRule = require("./imports");
 const exportsRule = require("./exports");
 
 module.exports = {
+  configs: {
+    recommended: {
+      parserOptions: {
+        sourceType: "module",
+      },
+      plugins: ["simple-import-sort"],
+      rules: {
+        "simple-import-sort/imports": "error",
+        "simple-import-sort/exports": "error",
+      },
+    },
+  },
   rules: {
     imports: importsRule,
     exports: exportsRule,


### PR DESCRIPTION
This PR adds a recommended config so users can enable simple-import-sort by extending their config. It loads the plugin and enables both rules.

```
extends: [
  // ... pre-existing extends
  "plugin:simple-import-sort/recommended"
],
```

It also includes the needed `sourceType: "module"` mentioned in the docs.