### PR TITLE
Add support for TypeScript import assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ import g from ".";
 import h from "./constants";
 import i from "./styles";
 
+// TypeScript import assignments.
+import J = require("../parent");
+import J = require("./sibling");
+export import K = require("an-npm-package");
+import L = require("different-npm-package");
+import M = Namespace;
+export import N = Namespace.A.B.C;
+import O = Namespace.A.C;
+
 // Different types of exports:
 export { a } from "../..";
 export { b } from "/";
@@ -365,6 +374,8 @@ Side effect imports have `\u0000` _prepended_ to their `from` string (starts wit
 
 Type imports have `\u0000` _appended_ to their `from` string (ends with `\u0000`). You can match them with `"\\u0000$"` – but you probably need more than that to avoid them also being matched by other regexes.
 
+TypeScript import assignments have `\u0001` (for `import A = require("A")`) or `\u0002` (for `import A = B.C.D`) prepended to their `from` string (starts with `\u0001` or `\u0002`). It is _not_ possible to distinguish `export import A =` and `import A =`.
+
 All imports that match the same regex are sorted internally as mentioned in [Sort order].
 
 This is the default value for the `groups` option:
@@ -384,6 +395,8 @@ This is the default value for the `groups` option:
   // Relative imports.
   // Anything that starts with a dot.
   ["^\\."],
+  // TypeScript import assignments.
+  ["^\\u0001", "^\\u0002"],
 ];
 ```
 
@@ -677,7 +690,7 @@ Use [custom grouping], setting the `groups` option to only have a single inner a
 For example, here’s the default value but changed to a single inner array:
 
 ```js
-[["^\\u0000", "^node:", "^@?\\w", "^", "^\\."]];
+[["^\\u0000", "^node:", "^@?\\w", "^", "^\\.", "^\\u0001", "^\\u0002"]];
 ```
 
 (By default, each string is in its _own_ array (that’s 5 inner arrays) – causing a blank line between each.)

--- a/README.md
+++ b/README.md
@@ -515,6 +515,8 @@ The final whitespace rule is that this plugin puts one import/export per line. I
 
 No. This is intentional to keep things simple. Use some other sorting rule, such as [import/order], for sorting `require`. Or consider migrating your code using `require` to `import`. `import` is well supported these days.
 
+The only `require`-like thing supported is TypeScript import assignments like `import Thing = require("something")`. They’re much easier to support since they are very restricted: The thing to the left of the `=` has to be a single identifier, and inside `require()` there has to be a single string literal. This makes it sortable as if it was `import Thing from "something"`.
+
 ### Why sort on `from`?
 
 Some other import sorting rules sort based on the first name after `import`, rather than the string after `from`. This plugin intentionally sorts on the `from` string to be `git diff` friendly.

--- a/README.md
+++ b/README.md
@@ -256,12 +256,12 @@ import i from "./styles";
 
 // TypeScript import assignments.
 import J = require("../parent");
-import J = require("./sibling");
-export import K = require("an-npm-package");
-import L = require("different-npm-package");
-import M = Namespace;
-export import N = Namespace.A.B.C;
-import O = Namespace.A.C;
+import K = require("./sibling");
+export import L = require("an-npm-package");
+import M = require("different-npm-package");
+import N = Namespace;
+export import O = Namespace.A.B.C;
+import P = Namespace.A.C;
 
 // Different types of exports:
 export { a } from "../..";

--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -103,7 +103,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but with no blank lines.
-            groups: [["^\\u0000", "^node:", "^@?\\w", "^", "^\\."]],
+            groups: [["^\\u0000", "^node:", "^@?\\w", "^", "^\\.", "^\\u0001", "^\\u0002"]],
           },
         ],
       },
@@ -115,7 +115,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but in reverse.
-            groups: [["^\\."], ["^"], ["^@?\\w"], ["^node:"], ["^\\u0000"]],
+            groups: [["^\\u0001", "^\\u0002"], ["^\\."], ["^"], ["^@?\\w"], ["^node:"], ["^\\u0000"]],
           },
         ],
       },
@@ -128,7 +128,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but with type imports first as a separate group.
-            groups: [["^.*\\u0000$"], ["^\\u0000"], ["^node:"], ["^@?\\w"], ["^"], ["^\\."]],
+            groups: [["^.*\\u0000$"], ["^\\u0000"], ["^node:"], ["^@?\\w"], ["^"], ["^\\."], ["^\\u0001", "^\\u0002"]],
           },
         ],
       },
@@ -141,7 +141,7 @@ module.exports = {
           "error",
           {
             // The default grouping, but with type imports last as a separate group.
-            groups: [["^\\u0000"], ["^node:"], ["^@?\\w"], ["^"], ["^\\."], ["^.+\\u0000$"]],
+            groups: [["^\\u0000"], ["^node:"], ["^@?\\w"], ["^"], ["^\\."], ["^\\u0001", "^\\u0002"], ["^.+\\u0000$"]],
           },
         ],
       },
@@ -162,6 +162,7 @@ module.exports = {
               ["^@?\\w"],
               ["^"],
               ["^\\."],
+              ["^\\u0001", "^\\u0002"],
             ],
           },
         ],
@@ -182,6 +183,7 @@ module.exports = {
               ["^@?\\w"],
               ["^"],
               ["^\\."],
+              ["^\\u0001", "^\\u0002"],
               ["^node:.*\\u0000$", "^@?\\w.*\\u0000$", "^[^.].*\\u0000$", "^\\..*\\u0000$"],
             ],
           },
@@ -202,6 +204,7 @@ module.exports = {
               ["^@?\\w.*\\u0000$", "^@?\\w"],
               ["(?<=\\u0000)$", "^"],
               ["^\\..*\\u0000$", "^\\."],
+              ["^\\u0001", "^\\u0002"],
             ],
           },
         ],

--- a/examples/readme-order.prettier.ts
+++ b/examples/readme-order.prettier.ts
@@ -27,12 +27,12 @@ import i from "./styles";
 
 // TypeScript import assignments.
 import J = require("../parent");
-import J = require("./sibling");
-export import K = require("an-npm-package");
-import L = require("different-npm-package");
-import M = Namespace;
-export import N = Namespace.A.B.C;
-import O = Namespace.A.C;
+import K = require("./sibling");
+export import L = require("an-npm-package");
+import M = require("different-npm-package");
+import N = Namespace;
+export import O = Namespace.A.B.C;
+import P = Namespace.A.C;
 
 // Different types of exports:
 export { a } from "../..";

--- a/examples/readme-order.prettier.ts
+++ b/examples/readme-order.prettier.ts
@@ -25,6 +25,15 @@ import g from ".";
 import h from "./constants";
 import i from "./styles";
 
+// TypeScript import assignments.
+import J = require("../parent");
+import J = require("./sibling");
+export import K = require("an-npm-package");
+import L = require("different-npm-package");
+import M = Namespace;
+export import N = Namespace.A.B.C;
+import O = Namespace.A.C;
+
 // Different types of exports:
 export { a } from "../..";
 export { b } from "/";

--- a/src/imports.js
+++ b/src/imports.js
@@ -147,7 +147,7 @@ function getSpecifiers(importNode) {
 function isImport(node) {
   return (
     node.type === "ImportDeclaration" ||
-    (node.type === "TSImportEqualsDeclaration" && !node.isExport)
+    node.type === "TSImportEqualsDeclaration"
   );
 }
 

--- a/src/imports.js
+++ b/src/imports.js
@@ -145,8 +145,7 @@ function getSourceWithControlCharacter(originalSource, item) {
       return `\u0001${originalSource}`;
     case shared.KIND_TS_IMPORT_ASSIGNMENT_NAMESPACE:
       return `\u0002${originalSource}`;
-    default:
-      // `type` and `typeof`.
+    default: // `type` and `typeof`.
       return `${originalSource}\u0000`;
   }
 }
@@ -156,7 +155,7 @@ function getSpecifiers(importNode) {
   switch (importNode.type) {
     case "TSImportEqualsDeclaration":
       return [];
-    default:
+    default: // ImportDeclaration
       return importNode.specifiers.filter((node) => isImportSpecifier(node));
   }
 }
@@ -182,7 +181,7 @@ function isSideEffectImport(importNode, sourceCode) {
   switch (importNode.type) {
     case "TSImportEqualsDeclaration":
       return false;
-    default:
+    default: // ImportDeclaration
       return (
         importNode.specifiers.length === 0 &&
         (!importNode.importKind ||

--- a/src/imports.js
+++ b/src/imports.js
@@ -147,7 +147,7 @@ function getSpecifiers(importNode) {
 function isImport(node) {
   return (
     node.type === "ImportDeclaration" ||
-    node.type === "TSImportEqualsDeclaration"
+    (node.type === "TSImportEqualsDeclaration" && !node.isExport)
   );
 }
 

--- a/src/imports.js
+++ b/src/imports.js
@@ -99,9 +99,10 @@ function makeSortedItems(items, outerGroups) {
 
   for (const item of items) {
     const { originalSource } = item.source;
-    const sourceWithControlCharacter = item.isSideEffectImport
-      ? `\0${originalSource}`
-      : getSourceWithControlCharacterFromKind(originalSource, item.source.kind);
+    const sourceWithControlCharacter = getSourceWithControlCharacter(
+      originalSource,
+      item
+    );
     const [matchedGroup] = shared
       .flatMap(itemGroups, (groups) =>
         groups.map((group) => [
@@ -133,8 +134,11 @@ function makeSortedItems(items, outerGroups) {
     );
 }
 
-function getSourceWithControlCharacterFromKind(originalSource, kind) {
-  switch (kind) {
+function getSourceWithControlCharacter(originalSource, item) {
+  if (item.isSideEffectImport) {
+    return `\0${originalSource}`;
+  }
+  switch (item.source.kind) {
     case shared.KIND_VALUE:
       return originalSource;
     case shared.KIND_TS_IMPORT_ASSIGNMENT_REQUIRE:

--- a/src/imports.js
+++ b/src/imports.js
@@ -153,10 +153,13 @@ function getSourceWithControlCharacter(originalSource, item) {
 // Exclude "ImportDefaultSpecifier" – the "def" in `import def, {a, b}`.
 function getSpecifiers(importNode) {
   switch (importNode.type) {
+    case "ImportDeclaration":
+      return importNode.specifiers.filter((node) => isImportSpecifier(node));
     case "TSImportEqualsDeclaration":
       return [];
-    default: // ImportDeclaration
-      return importNode.specifiers.filter((node) => isImportSpecifier(node));
+    // istanbul ignore next
+    default:
+      throw new Error(`Unsupported import node type: ${importNode.type}`);
   }
 }
 
@@ -179,9 +182,7 @@ function isImportSpecifier(node) {
 // And not: import type {} from "setup"
 function isSideEffectImport(importNode, sourceCode) {
   switch (importNode.type) {
-    case "TSImportEqualsDeclaration":
-      return false;
-    default: // ImportDeclaration
+    case "ImportDeclaration":
       return (
         importNode.specifiers.length === 0 &&
         (!importNode.importKind ||
@@ -191,5 +192,10 @@ function isSideEffectImport(importNode, sourceCode) {
           "{"
         )
       );
+    case "TSImportEqualsDeclaration":
+      return false;
+    // istanbul ignore next
+    default:
+      throw new Error(`Unsupported import node type: ${importNode.type}`);
   }
 }

--- a/src/shared.js
+++ b/src/shared.js
@@ -840,6 +840,9 @@ function getSourceFromModuleReference(sourceCode, node) {
     case "TSQualifiedName": {
       return `= ${getSourceFromTSQualifiedName(sourceCode, node)}`;
     }
+    case "Identifier": {
+      return `= ${node.name}`;
+    }
     default: {
       return ``;
     }

--- a/src/shared.js
+++ b/src/shared.js
@@ -795,11 +795,55 @@ function isNewline(node) {
   return node.type === "Newline";
 }
 
+function getSourceFromTSQualifiedName(sourceCode, node) {
+  let left;
+  let right;
+  switch (node.left.type) {
+    case "Identifier": {
+      left = node.left.name;
+      break;
+    }
+    case "TSQualifiedName": {
+      left = getSourceFromTSQualifiedName(sourceCode, node.left);
+      break;
+    }
+    default: {
+      left = ``;
+      break;
+    }
+  }
+  switch (node.right.type) {
+    case "Identifier": {
+      right = `.${node.right.name}`;
+      break;
+    }
+    default: {
+      right = ``;
+      break;
+    }
+  }
+  return left + right;
+}
+
+function getSourceFromModuleReference(sourceCode, node) {
+  switch (node.type) {
+    case "TSExternalModuleReference": {
+      return node.expression.value;
+    }
+    case "TSQualifiedName": {
+      return `= ${getSourceFromTSQualifiedName(sourceCode, node)}`;
+    }
+    default: {
+      return ``;
+    }
+  }
+}
+
 function getSource(sourceCode, node) {
   let source;
   switch (node.type) {
     case "TSImportEqualsDeclaration": {
-      source = `= ${sourceCode.text.slice(...node.moduleReference.range)}`;
+      source = getSourceFromModuleReference(sourceCode, node.moduleReference);
       break;
     }
     default: {

--- a/src/shared.js
+++ b/src/shared.js
@@ -164,7 +164,7 @@ function getImportExportItems(
     const [start] = all[0].range;
     const [, end] = all[all.length - 1].range;
 
-    const source = getSource(node);
+    const source = getSource(sourceCode, node);
 
     return {
       node,
@@ -795,8 +795,18 @@ function isNewline(node) {
   return node.type === "Newline";
 }
 
-function getSource(node) {
-  const source = node.source.value;
+function getSource(sourceCode, node) {
+  let source;
+  switch (node.type) {
+    case "TSImportEqualsDeclaration": {
+      source = `= ${sourceCode.text.slice(...node.moduleReference.range)}`;
+      break;
+    }
+    default: {
+      source = node.source.value;
+      break;
+    }
+  }
 
   return {
     // Sort by directory level rather than by string length.

--- a/src/shared.js
+++ b/src/shared.js
@@ -848,6 +848,10 @@ const KIND_TS_IMPORT_ASSIGNMENT_NAMESPACE = "z_namespace";
 function getSourceTextAndKindFromModuleReference(sourceCode, node) {
   switch (node.type) {
     case "TSExternalModuleReference":
+      // Only string literals inside `require()` are allowed by
+      // TypeScript, but the parser supports anything. Sorting
+      // is defined for string literals only. For other expressions,
+      // we just make sure not to crash.
       switch (node.expression.type) {
         case "Literal":
           return [

--- a/src/shared.js
+++ b/src/shared.js
@@ -831,13 +831,18 @@ function getSource(sourceCode, node) {
 
 function getSourceTextAndKind(sourceCode, node) {
   switch (node.type) {
+    case "ImportDeclaration":
+    case "ExportNamedDeclaration":
+    case "ExportAllDeclaration":
+      return [node.source.value, getImportExportKind(node)];
     case "TSImportEqualsDeclaration":
       return getSourceTextAndKindFromModuleReference(
         sourceCode,
         node.moduleReference
       );
-    default: // ImportDeclaration, ExportNamedDeclaration, ExportAllDeclaration
-      return [node.source.value, getImportExportKind(node)];
+    // istanbul ignore next
+    default:
+      throw new Error(`Unsupported import node type: ${node.type}`);
   }
 }
 
@@ -873,19 +878,25 @@ function getSourceTextAndKindFromModuleReference(sourceCode, node) {
         getSourceTextFromTSQualifiedName(sourceCode, node),
         KIND_TS_IMPORT_ASSIGNMENT_NAMESPACE,
       ];
-    default: // Identifier
+    case "Identifier":
       return [node.name, KIND_TS_IMPORT_ASSIGNMENT_NAMESPACE];
+    // istanbul ignore next
+    default:
+      throw new Error(`Unsupported module reference node type: ${node.type}`);
   }
 }
 
 function getSourceTextFromTSQualifiedName(sourceCode, node) {
   switch (node.left.type) {
+    case "Identifier":
+      return `${node.left.name}.${node.right.name}`;
     case "TSQualifiedName":
       return `${getSourceTextFromTSQualifiedName(sourceCode, node.left)}.${
         node.right.name
       }`;
-    default: // Identifier
-      return `${node.left.name}.${node.right.name}`;
+    // istanbul ignore next
+    default:
+      throw new Error(`Unsupported TS qualified name node type: ${node.type}`);
   }
 }
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -842,7 +842,7 @@ function getSourceTextAndKind(sourceCode, node) {
       );
     // istanbul ignore next
     default:
-      throw new Error(`Unsupported import node type: ${node.type}`);
+      throw new Error(`Unsupported import/export node type: ${node.type}`);
   }
 }
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -828,7 +828,14 @@ function getSourceFromTSQualifiedName(sourceCode, node) {
 function getSourceFromModuleReference(sourceCode, node) {
   switch (node.type) {
     case "TSExternalModuleReference": {
-      return node.expression.value;
+      switch (node.expression.type) {
+        case "Literal": {
+          return node.expression.value;
+        }
+        default: {
+          return sourceCode.text.slice(...node.expression.range);
+        }
+      }
     }
     case "TSQualifiedName": {
       return `= ${getSourceFromTSQualifiedName(sourceCode, node)}`;

--- a/src/shared.js
+++ b/src/shared.js
@@ -836,7 +836,7 @@ function getSourceTextAndKind(sourceCode, node) {
         sourceCode,
         node.moduleReference
       );
-    default:
+    default: // ImportDeclaration, ExportNamedDeclaration, ExportAllDeclaration
       return [node.source.value, getImportExportKind(node)];
   }
 }
@@ -873,7 +873,7 @@ function getSourceTextAndKindFromModuleReference(sourceCode, node) {
         getSourceTextFromTSQualifiedName(sourceCode, node),
         KIND_TS_IMPORT_ASSIGNMENT_NAMESPACE,
       ];
-    default:
+    default: // Identifier
       return [node.name, KIND_TS_IMPORT_ASSIGNMENT_NAMESPACE];
   }
 }
@@ -884,9 +884,8 @@ function getSourceTextFromTSQualifiedName(sourceCode, node) {
       return `${getSourceTextFromTSQualifiedName(sourceCode, node.left)}.${
         node.right.name
       }`;
-    default: {
+    default: // Identifier
       return `${node.left.name}.${node.right.name}`;
-    }
   }
 }
 

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -496,6 +496,15 @@ import g from ".";
 import h from "./constants";
 import i from "./styles";
 
+// TypeScript import assignments.
+import J = require("../parent");
+import J = require("./sibling");
+export import K = require("an-npm-package");
+import L = require("different-npm-package");
+import M = Namespace;
+export import N = Namespace.A.B.C;
+import O = Namespace.A.C;
+
 // Different types of exports:
 export { a } from "../..";
 export { b } from "/";

--- a/test/__snapshots__/examples.test.js.snap
+++ b/test/__snapshots__/examples.test.js.snap
@@ -498,12 +498,12 @@ import i from "./styles";
 
 // TypeScript import assignments.
 import J = require("../parent");
-import J = require("./sibling");
-export import K = require("an-npm-package");
-import L = require("different-npm-package");
-import M = Namespace;
-export import N = Namespace.A.B.C;
-import O = Namespace.A.C;
+import K = require("./sibling");
+export import L = require("an-npm-package");
+import M = require("different-npm-package");
+import N = Namespace;
+export import O = Namespace.A.B.C;
+import P = Namespace.A.C;
 
 // Different types of exports:
 export { a } from "../..";

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -2038,7 +2038,7 @@ const typescriptTests = {
       errors: 3,
     },
 
-    // Namespace imports.
+    // Import assignments.
     {
       code: input`
           |import { Namespace } from './namespace';
@@ -2051,6 +2051,39 @@ const typescriptTests = {
           |import { Namespace } from './namespace';
           |
           |import Foo = Namespace.Foo;
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |import B = require('./b');
+          |import A = require('./a');
+          |import Foo = require('foo');
+          |import Bar = require('../foo');
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import Foo = require('foo');
+          |
+          |import Bar = require('../foo');
+          |import A = require('./a');
+          |import B = require('./b');
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |import B = Namespace/*aaaa*/.B;
+          |import AB = Namespace.A.B;
+          |import A = Namespace.A.A;
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import A = Namespace.A.A;
+          |import AB = Namespace.A.B;
+          |import B = Namespace/*aaaa*/.B;
         `);
       },
       errors: 1,

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -2037,6 +2037,24 @@ const typescriptTests = {
       },
       errors: 3,
     },
+
+    // Namespace imports.
+    {
+      code: input`
+          |import { Namespace } from './namespace';
+          |import Foo = Namespace.Foo;
+          |import { bar } from './a';
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import { bar } from './a';
+          |import { Namespace } from './namespace';
+          |
+          |import Foo = Namespace.Foo;
+        `);
+      },
+      errors: 1,
+    },
   ],
 };
 

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -1858,8 +1858,8 @@ const typescriptTests = {
     input`
           |export namespace Foo {
           |  import A = _A;
-          |  export import Enum = _Enum;
           |  import B = _B;
+          |  export import Enum = _Enum;
           |}
       `,
   ],
@@ -2114,8 +2114,8 @@ const typescriptTests = {
       code: input`
           |export namespace Foo {
           |  import B = _B;
-          |  import A = _A;
           |  export import Enum = _Enum;
+          |  import A = _A;
           |}
       `,
       output: (actual) => {

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -1855,6 +1855,13 @@ const typescriptTests = {
           |import type x1 from "a";
           |import type x2 from "b"
     `,
+    input`
+          |export namespace Foo {
+          |  import A = _A;
+          |  export import Enum = _Enum;
+          |  import B = _B;
+          |}
+      `,
   ],
   invalid: [
     // Type imports.
@@ -2099,6 +2106,25 @@ const typescriptTests = {
           |import A = Namespace.A.A;
           |import AB = Namespace.A.B;
           |import B = Namespace/*aaaa*/.B;
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
+          |export namespace Foo {
+          |  import B = _B;
+          |  import A = _A;
+          |  export import Enum = _Enum;
+          |}
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export namespace Foo {
+          |  import A = _A;
+          |  import B = _B;
+          |  export import Enum = _Enum;
+          |}
         `);
       },
       errors: 1,

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -2075,6 +2075,21 @@ const typescriptTests = {
     },
     {
       code: input`
+          |import Foo = require('foo');
+          |import Bar = require(cool().thing);
+          |import Bar = require(1 + 1);
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import Bar = require(1 + 1);
+          |import Bar = require(cool().thing);
+          |import Foo = require('foo');
+        `);
+      },
+      errors: 1,
+    },
+    {
+      code: input`
           |import B = Namespace/*aaaa*/.B;
           |import AB = Namespace.A.B;
           |import A = Namespace.A.A;

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -2103,6 +2103,8 @@ const typescriptTests = {
       errors: 1,
     },
     {
+      // This is invalid TypeScript, but supported by the parser.
+      // The order here doesn’t matter – we should just not crash.
       code: input`
           |import A = require(null);
           |import A = require(cool().thing);


### PR DESCRIPTION
Right now TypeScript namespace imports breaks sorting. It will fix this problem...

Closes https://github.com/lydell/eslint-plugin-simple-import-sort/issues/144