### PR TITLE
Add meta property and flat config docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,24 +69,39 @@ npm install --save-dev eslint-plugin-simple-import-sort
 
 ## Usage
 
-Add `"simple-import-sort"` to `"plugins"` in your .eslintrc:
+- [eslintrc]: Add `"simple-import-sort"` to the "plugins" array in your `.eslintrc.*` file, and add the rules for sorting imports and exports. By default ESLint doesn’t parse `import` syntax – the "parserOptions" is an example of how to enable that.
 
-```json
-{
-  "plugins": ["simple-import-sort"]
-}
-```
-
-Then add the rules for sorting imports and exports:
-
-```json
-{
-  "rules": {
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error"
+  ```json
+  {
+    "plugins": ["simple-import-sort"],
+    "rules": {
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error"
+    },
+    "parserOptions": {
+      "sourceType": "module",
+      "ecmaVersion": "latest"
+    }
   }
-}
-```
+  ```
+
+- [eslint.config.js (flat config)]: Import eslint-plugin-simple-import-sort, put it in the `plugins` object, and add the rules for sorting imports and exports. With flat config, `import` syntax is enabled by default.
+
+  ```js
+  import simpleImportSort from "eslint-plugin-simple-import-sort";
+
+  export default [
+    {
+      plugins: {
+        "simple-import-sort": simpleImportSort,
+      },
+      rules: {
+        "simple-import-sort/imports": "error",
+        "simple-import-sort/exports": "error",
+      },
+    },
+  ];
+  ```
 
 Make sure _not_ to use other sorting rules at the same time:
 
@@ -104,9 +119,9 @@ It is recommended to also set up [Prettier], to help formatting your imports (an
 ```json
 {
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": "latest"
   },
-  "env": { "es6": true },
   "plugins": ["simple-import-sort", "import"],
   "rules": {
     "simple-import-sort/imports": "error",
@@ -118,7 +133,7 @@ It is recommended to also set up [Prettier], to help formatting your imports (an
 }
 ```
 
-- `"sourceType": "module"` is needed so ESLint doesn’t report `import` and `export` as syntax errors.
+- `"sourceType": "module"` and `"ecmaVersion": "latest"` are needed so ESLint doesn’t report `import` and `export` as syntax errors.
 - `simple-import-sort/imports` and `simple-import-sort/exports` are turned on for all files.
 - [import/first] makes sure all imports are at the top of the file. (autofixable)
 - [import/newline-after-import] makes sure there’s a newline after the imports. (autofixable)
@@ -706,7 +721,9 @@ For example, here’s the default value but changed to a single inner array:
 [comment-handling]: #comment-and-whitespace-handling
 [custom grouping]: #custom-grouping
 [eslint-getting-started]: https://eslint.org/docs/user-guide/getting-started
+[eslint.config.js (flat config)]: https://eslint.org/docs/latest/use/configure/configuration-files-new
 [eslint]: https://eslint.org/
+[eslintrc]: https://eslint.org/docs/latest/use/configure/configuration-files
 [example-ignore]: ./examples/ignore.js
 [examples]: ./examples/.eslintrc.js
 [exports]: #exports

--- a/build.js
+++ b/build.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const path = require("path");
+const PACKAGE = require("./package-real.json");
 
 const DIR = __dirname;
 const SRC = "src";
@@ -19,7 +20,11 @@ const FILES_TO_COPY = [
   },
   ...fs
     .readdirSync(SRC)
-    .map((file) => ({ src: path.join(SRC, file), dest: file })),
+    .map((file) => ({
+      src: path.join(SRC, file),
+      dest: file,
+      transform: (content) => content.replace(/%VERSION%/g, PACKAGE.version),
+    })),
 ];
 
 fs.rmSync(BUILD, { recursive: true, force: true });

--- a/build.js
+++ b/build.js
@@ -18,13 +18,11 @@ const FILES_TO_COPY = [
     src: "README.md",
     transform: (content) => content.replace(/<!--[^]*$/, READ_MORE),
   },
-  ...fs
-    .readdirSync(SRC)
-    .map((file) => ({
-      src: path.join(SRC, file),
-      dest: file,
-      transform: (content) => content.replace(/%VERSION%/g, PACKAGE.version),
-    })),
+  ...fs.readdirSync(SRC).map((file) => ({
+    src: path.join(SRC, file),
+    dest: file,
+    transform: (content) => content.replace(/%VERSION%/g, PACKAGE.version),
+  })),
 ];
 
 fs.rmSync(BUILD, { recursive: true, force: true });

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,10 @@ const importsRule = require("./imports");
 const exportsRule = require("./exports");
 
 module.exports = {
+  meta: {
+    name: "eslint-plugin-simple-import-sort",
+    version: "%VERSION%",
+  },
   rules: {
     imports: importsRule,
     exports: exportsRule,


### PR DESCRIPTION
The flat config migration docs says to add the `meta` property with `name` and `version`: https://eslint.org/docs/latest/extend/plugin-migration-flat-config#adding-plugin-meta-information

/cc @JoshuaKGoldberg if you want to update https://github.com/eslint/eslint/issues/18093 :)