### PR TITLE
Add support @typescript-eslint/parser@6

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,13 +1,15 @@
 "use strict";
 
+const expectedCoverage = process.version.startsWith("v14") ? 98 : 100;
+
 module.exports = {
   collectCoverageFrom: ["src/**/*.js"],
   coverageThreshold: {
     global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
+      branches: expectedCoverage,
+      functions: expectedCoverage,
+      lines: expectedCoverage,
+      statements: expectedCoverage,
     },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
         "@babel/plugin-syntax-import-assertions": "7.20.0",
         "@babel/plugin-transform-flow-strip-types": "7.19.0",
         "@typescript-eslint/parser": "5.48.1",
+        "@typescript-eslint/parser-v5": "npm:@typescript-eslint/parser@5.48.1",
+        "@typescript-eslint/parser-v6": "npm:@typescript-eslint/parser@6.21.0",
         "eslint": "8.56.0",
         "eslint-plugin-import": "2.27.4",
         "eslint-plugin-jest": "27.2.1",
@@ -1753,6 +1755,207 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@typescript-eslint/parser-v5": {
+      "name": "@typescript-eslint/parser",
+      "version": "5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.1.tgz",
+      "integrity": "sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/typescript-estree": "5.48.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6": {
+      "name": "@typescript-eslint/parser",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser-v6/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.48.1",
@@ -7048,6 +7251,18 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -8848,6 +9063,123 @@
         "@typescript-eslint/types": "5.48.1",
         "@typescript-eslint/typescript-estree": "5.48.1",
         "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/parser-v5": {
+      "version": "npm:@typescript-eslint/parser@5.48.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.48.1.tgz",
+      "integrity": "sha512-4yg+FJR/V1M9Xoq56SF9Iygqm+r5LMXvheo6DQ7/yUWynQ4YfCRnsKuRgqH4EQ5Ya76rVwlEpw4Xu+TgWQUcdA==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.48.1",
+        "@typescript-eslint/types": "5.48.1",
+        "@typescript-eslint/typescript-estree": "5.48.1",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/parser-v6": {
+      "version": "npm:@typescript-eslint/parser@6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+          "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.21.0",
+            "@typescript-eslint/visitor-keys": "6.21.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+          "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+          "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.21.0",
+            "@typescript-eslint/visitor-keys": "6.21.0",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "minimatch": "9.0.3",
+            "semver": "^7.5.4",
+            "ts-api-utils": "^1.0.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "6.21.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+          "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "6.21.0",
+            "eslint-visitor-keys": "^3.4.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/scope-manager": {
@@ -12679,6 +13011,13 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "ts-api-utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.2.1.tgz",
+      "integrity": "sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==",
+      "dev": true,
+      "requires": {}
     },
     "tsconfig-paths": {
       "version": "3.14.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@babel/plugin-syntax-import-assertions": "7.20.0",
     "@babel/plugin-transform-flow-strip-types": "7.19.0",
     "@typescript-eslint/parser": "5.48.1",
+    "@typescript-eslint/parser-v5": "npm:@typescript-eslint/parser@5.48.1",
+    "@typescript-eslint/parser-v6": "npm:@typescript-eslint/parser@6.21.0",
     "eslint": "8.56.0",
     "eslint-plugin-import": "2.27.4",
     "eslint-plugin-jest": "27.2.1",

--- a/src/shared.js
+++ b/src/shared.js
@@ -832,7 +832,6 @@ function getSource(sourceCode, node) {
 function getSourceTextAndKind(sourceCode, node) {
   switch (node.type) {
     case "ImportDeclaration":
-    case "ExportNamedDeclaration":
     case "ExportAllDeclaration":
       return [node.source.value, getImportExportKind(node)];
     case "TSImportEqualsDeclaration":
@@ -840,6 +839,18 @@ function getSourceTextAndKind(sourceCode, node) {
         sourceCode,
         node.moduleReference
       );
+    case "ExportNamedDeclaration": {
+      if (
+        node.declaration &&
+        node.declaration.type === "TSImportEqualsDeclaration"
+      ) {
+        return getSourceTextAndKindFromModuleReference(
+          sourceCode,
+          node.declaration.moduleReference
+        );
+      }
+      return [node.source.value, getImportExportKind(node)];
+    }
     // istanbul ignore next
     default:
       throw new Error(`Unsupported import/export node type: ${node.type}`);

--- a/test/examples.test.js
+++ b/test/examples.test.js
@@ -23,6 +23,10 @@ describe("examples", () => {
     }
   );
 
+  if (result.stderr) {
+    throw new Error(result.stderr);
+  }
+
   const output = JSON.parse(result.stdout);
 
   for (const item of output) {

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -1166,8 +1166,13 @@ const flowRuleTester = new RuleTester({
   parser: require.resolve("@babel/eslint-parser"),
 });
 
-const typescriptRuleTester = new RuleTester({
-  parser: require.resolve("@typescript-eslint/parser"),
+const typescriptEslint5RuleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser-v5"),
+  parserOptions: { sourceType: "module" },
+});
+
+const typescriptEslint6RuleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser-v6"),
   parserOptions: { sourceType: "module" },
 });
 
@@ -1175,16 +1180,30 @@ javascriptRuleTester.run("JavaScript", plugin.rules.exports, baseTests(expect));
 
 flowRuleTester.run("Flow", plugin.rules.exports, baseTests(expect2));
 
-typescriptRuleTester.run(
-  "TypeScript",
+typescriptEslint5RuleTester.run(
+  "TypeScript (parser v5)",
   plugin.rules.exports,
   baseTests(expect2)
 );
 
 flowRuleTester.run("Flow-specific", plugin.rules.exports, flowTests);
 
-typescriptRuleTester.run(
-  "TypeScript-specific",
+typescriptEslint5RuleTester.run(
+  "TypeScript-specific (parser v5)",
   plugin.rules.exports,
   typescriptTests
 );
+
+if (!process.version.startsWith("v14")) {
+  typescriptEslint6RuleTester.run(
+    "TypeScript (parser v6)",
+    plugin.rules.exports,
+    baseTests(expect2)
+  );
+
+  typescriptEslint6RuleTester.run(
+    "TypeScript-specific (parser v6)",
+    plugin.rules.exports,
+    typescriptTests
+  );
+}

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -2259,8 +2259,13 @@ const flowRuleTester = new RuleTester({
   parser: require.resolve("@babel/eslint-parser"),
 });
 
-const typescriptRuleTester = new RuleTester({
-  parser: require.resolve("@typescript-eslint/parser"),
+const typescriptEslint5RuleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser-v5"),
+  parserOptions: { sourceType: "module" },
+});
+
+const typescriptEslint6RuleTester = new RuleTester({
+  parser: require.resolve("@typescript-eslint/parser-v6"),
   parserOptions: { sourceType: "module" },
 });
 
@@ -2268,16 +2273,30 @@ javascriptRuleTester.run("JavaScript", plugin.rules.imports, baseTests(expect));
 
 flowRuleTester.run("Flow", plugin.rules.imports, baseTests(expect2));
 
-typescriptRuleTester.run(
-  "TypeScript",
+typescriptEslint5RuleTester.run(
+  "TypeScript (parser v5)",
   plugin.rules.imports,
   baseTests(expect2)
 );
 
 flowRuleTester.run("Flow-specific", plugin.rules.imports, flowTests);
 
-typescriptRuleTester.run(
-  "TypeScript-specific",
+typescriptEslint5RuleTester.run(
+  "TypeScript-specific (parser v5)",
   plugin.rules.imports,
   typescriptTests
 );
+
+if (!process.version.startsWith("v14")) {
+  typescriptEslint6RuleTester.run(
+    "TypeScript (parser v6)",
+    plugin.rules.imports,
+    baseTests(expect2)
+  );
+
+  typescriptEslint6RuleTester.run(
+    "TypeScript-specific (parser v6)",
+    plugin.rules.imports,
+    typescriptTests
+  );
+}


### PR DESCRIPTION
In v5 we had this structure for `export import`:

```
TSModuleBlock.body [
    TSImportEqualsDeclaration.isExport true
]
```

In v6 this structure was changed:

```
TSModuleBlock.body [
    ExportNamedDeclaration.declaration
        TSImportEqualsDeclaration
]
```

Property `isExport` in `TSImportEqualsDeclaration` was removed, and `TSImportEqualsDeclaration` placed into `ExportNamedDeclaration.declaration` instead.

To maintain the current logic, added processing of the new structure. But perhaps in the future it is worth considering equating `export import` to exports instead of imports.

Closes: #156 