### PR TITLE
Add types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,5 @@
+import type { ESLint } from "eslint";
+
+declare const eslintPluginSimpleImportSort: ESLint.Plugin;
+
+export = eslintPluginSimpleImportSort;


### PR DESCRIPTION
I just happened to already have types for this project in my own soon-to-be-published config. Ordinarily, configs, processors, parsers, and other custom exports would also need to be included, but as this plugin is quite *simple* 😉, only the basic plugin type needs to be used. For almost every use case, specific types for rules can be safely ignored as they are handled by ESLint internally with end users only referencing them by name.

fixes #163