### PR TITLE
Ship types for configs

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,3 +3,25 @@ import type { ESLint } from "eslint";
 declare const eslintPluginSimpleImportSort: ESLint.Plugin;
 
 export = eslintPluginSimpleImportSort;
+
+declare module "eslint-define-config" {
+  export interface CustomRuleOptions {
+    /**
+     * Automatically sort imports.
+     *
+     * @see [imports](https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/docs/rules/imports.md)
+     */
+    "simple-import-sort/imports": [
+      {
+        groups?: (RegExp | string)[][];
+      },
+    ];
+
+    /**
+     * Automatically sort exports.
+     *
+     * @see [exports](https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/docs/rules/exports.md)
+     */
+    "simple-import-sort/exports": [];
+  }
+}


### PR DESCRIPTION
@eslint-types is a useful project that allows strict typing of eslint configs. This adds types for our settings.