### PR TITLE
feat: adding "collapseTypesAbove" option to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,12 +341,13 @@ Workaround to make the next section to appear in the table of contents.
 
 ## Custom grouping
 
-There is **one** option (see [Not for everyone]) called `groups` that is useful for a bunch of different use cases.
+There are **two** options (see [Not for everyone]). They called `collapseTypesAbove` and `groups` which are useful for a bunch of different use cases.
 
-`groups` is an array of arrays of strings:
+`collapseTypesAbove` is a boolean and `groups` is an array of arrays of strings:
 
 ```ts
 type Options = {
+  collapseTypesAbove: boolean;
   groups: Array<Array<string>>;
 };
 ```
@@ -378,7 +379,7 @@ Imports that don’t match any regex are put together last.
 
 Side effect imports have `\u0000` _prepended_ to their `from` string (starts with `\u0000`). You can match them with `"^\\u0000"`.
 
-Type imports have `\u0000` _appended_ to their `from` string (ends with `\u0000`). You can match them with `"\\u0000$"` – but you probably need more than that to avoid them also being matched by other regexes.
+Type imports have `\u0000` _appended_ to their `from` string (ends with `\u0000`). You can match them with `"\\u0000$"` – but you probably need more than that to avoid them also being matched by other regexes. If you want to put all type imports at the top, you can set the `collapseTypesAbove` config option to `true`.
 
 All imports that match the same regex are sorted internally as mentioned in [Sort order].
 
@@ -386,6 +387,9 @@ This is the default value for the `groups` option:
 
 ```js
 [
+  // Type imports.
+  // Only if "collapseTypesAbove" config option was set to true.
+  [".*\\u0000$"]
   // Side effect imports.
   ["^\\u0000"],
   // Node.js builtins prefixed with `node:`.

--- a/examples/.eslintrc.js
+++ b/examples/.eslintrc.js
@@ -66,6 +66,19 @@ module.exports = {
       },
     },
     {
+      files: ["collapse-types-above.ts"],
+      parser: "@typescript-eslint/parser",
+      rules: {
+        imports: [
+          "error",
+          {
+            // The default grouping, but with type imports first as a separate group.
+            collapseTypesAbove: true,
+          },
+        ],
+      },
+    },
+    {
       files: ["groups.custom.js"],
       rules: {
         imports: [

--- a/examples/collapse-types-above.ts
+++ b/examples/collapse-types-above.ts
@@ -1,0 +1,18 @@
+import "./polyfills";
+import fs from "node:fs";
+import type { Dirent } from "node:fs";
+import type { ParsedPath } from "node:path";
+import * as path from "node:path";
+import react from "react";
+import type { Component } from "react";
+import type { Store } from "redux";
+import type { Story } from "@storybook/react";
+import { storiesOf } from "@storybook/react";
+import type { AppRouter } from "@/App";
+import App from "@/App";
+import type { Page } from "./page";
+import page from "./page";
+import type { Css } from "./styles";
+import styles from "./styles";
+import config from "/config";
+import type { Config } from "/config";

--- a/package-real.json
+++ b/package-real.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-simple-import-sort",
-  "version": "12.1.1",
+  "version": "12.2.1",
   "license": "MIT",
   "author": "Simon Lydell",
   "repository": "lydell/eslint-plugin-simple-import-sort",

--- a/src/imports.js
+++ b/src/imports.js
@@ -26,6 +26,9 @@ module.exports = {
       {
         type: "object",
         properties: {
+          collapseTypesAbove: {
+            type: "boolean",
+          },
           groups: {
             type: "array",
             items: {
@@ -48,6 +51,13 @@ module.exports = {
     },
   },
   create: (context) => {
+    const { collapseTypesAbove } = context.options[0] || {};
+
+    if (collapseTypesAbove) {
+      // Type imports.
+      defaultGroups.unshift([".*\\u0000$"]);
+    }
+
     const { groups: rawGroups = defaultGroups } = context.options[0] || {};
 
     const outerGroups = rawGroups.map((groups) =>

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -1939,6 +1939,42 @@ const typescriptTests = {
       errors: 1,
     },
 
+    // `collapseTypesAbove` – type imports.
+    {
+      options: [{ collapseTypesAbove: true }],
+      code: input`
+          |import '@/';
+          |import c from '@/';
+          |import type C from '@/';
+          |import b from './';
+          |import type B from './';
+          |import './';
+          |import a from 'a';
+          |import type A from 'a';
+          |import 'a';
+          |import {} from 'a';
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import type B from './';
+          |import type C from '@/';
+          |import type A from 'a';
+          |
+          |import '@/';
+          |import './';
+          |import 'a';
+          |
+          |import a from 'a';
+          |import {} from 'a';
+          |
+          |import c from '@/';
+          |
+          |import b from './';
+        `);
+      },
+      errors: 1,
+    },
+
     // `groups` – real-world example from issue #61 based on:
     // https://github.com/polkadot-js/apps/blob/074b245a725873f7c3c16fc83b80fb9c02351a65/packages/apps/src/Endpoints/Group.tsx
     // https://github.com/polkadot-js/apps/blob/074b245a725873f7c3c16fc83b80fb9c02351a65/.eslintrc.js#L31-L39


### PR DESCRIPTION
To optionally separate all imported types above others by default, I propose to add a new option "collapseTypesAbove" to the plugin configuration.