### PR TITLE
docs: fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,7 +605,7 @@ export * from "./two.js";
 _main.js:_
 
 ```js
-import * as reexport from "./rexport.js";
+import * as reexport from "./reexport.js";
 console.log(reexport);
 ```
 


### PR DESCRIPTION
First of all, thank you for this awesome plugin.

I found a type in the example of README.md and fixed it.