### PR TITLE
Fix autofix and sort order for quoted names

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -748,15 +748,18 @@ function sortSpecifierItems(items) {
       // export { b as a }
       //               ^
       compare(
-        (itemA.node.imported || itemA.node.exported).name,
-        (itemB.node.imported || itemB.node.exported).name,
+        getSpecifierName(itemA.node.imported || itemA.node.exported),
+        getSpecifierName(itemB.node.imported || itemB.node.exported),
       ) ||
       // Then compare by the file-local name.
       // import { a as b } from "a"
       //               ^
       // export { b as a }
       //          ^
-      compare(itemA.node.local.name, itemB.node.local.name) ||
+      compare(
+        getSpecifierName(itemA.node.local),
+        getSpecifierName(itemB.node.local),
+      ) ||
       // Then put type specifiers before regular ones.
       compare(
         getImportExportKind(itemA.node),
@@ -769,6 +772,19 @@ function sortSpecifierItems(items) {
       itemA.index - itemB.index,
     /* v8 ignore stop */
   );
+}
+
+// A specifier name is usually an identifier, but it can also be a string
+// (ES2022 arbitrary module namespace names):
+//
+//     import { "a-b" as c } from "a"
+//     export { c as "a-b" }
+//
+// Compare strings by their value (`a-b`) rather than their raw source text
+// (`"a-b"`), so that the quotes (and the choice of quote character) don’t
+// affect the sort order.
+function getSpecifierName(node) {
+  return node.type === "Literal" ? node.value : node.name;
 }
 
 const collator = new Intl.Collator("en", {

--- a/src/shared.js
+++ b/src/shared.js
@@ -463,13 +463,15 @@ function getSpecifierItems(tokens) {
     // trailing comments and whitespace from `.specifier` to `.after`, and
     // comments and whitespace that don’t belong to the specifier to
     // `result.after`. The last non-comment and non-whitespace token is usually
-    // an identifier, but in this case it’s a keyword:
+    // an identifier, but it can also be a keyword or a string:
     //
     //    export { z, d as default } from "a"
+    //    export { z, d as "d-d" } from "a"
     case "specifier": {
       const lastIdentifierIndex = findLastIndex(
         current.specifier,
-        (token2) => isIdentifier(token2) || isKeyword(token2),
+        (token2) =>
+          isIdentifier(token2) || isKeyword(token2) || isString(token2),
       );
 
       const specifier = current.specifier.slice(0, lastIdentifierIndex + 1);
@@ -784,6 +786,10 @@ function isIdentifier(node) {
 
 function isKeyword(node) {
   return node.type === "Keyword";
+}
+
+function isString(node) {
+  return node.type === "String";
 }
 
 function isPunctuator(node, value) {

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -789,6 +789,37 @@ const baseTests = (expect) => ({
   ],
 });
 
+// ES2022 arbitrary module namespace names (quoted names). These are tested
+// separately because they require `ecmaVersion: 2022`, and because the
+// TypeScript parser version used in these tests does not support them.
+const es2022Tests = {
+  valid: [
+    // Simple cases.
+    `export { a as "a b", z } from "x"`,
+    `export { a, z as "z z" } from "x"`,
+  ],
+
+  invalid: [
+    // A quoted name can be the last token of the last specifier.
+    {
+      code: `export { z, a as "a b" } from "x"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a as "a b",z } from "x"`,
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { z, "a-a" } from "x"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export { "a-a",z } from "x"`);
+      },
+      errors: 1,
+    },
+  ],
+};
+
 const flowTests = {
   valid: [
     // Simple cases.
@@ -1174,6 +1205,10 @@ const typescriptRuleTester = new RuleTester({
   parserOptions: { sourceType: "module" },
 });
 
+const es2022RuleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
 javascriptRuleTester.run("JavaScript", plugin.rules.exports, baseTests(expect));
 
 flowRuleTester.run("Flow", plugin.rules.exports, baseTests(expect2));
@@ -1191,3 +1226,5 @@ typescriptRuleTester.run(
   plugin.rules.exports,
   typescriptTests,
 );
+
+es2022RuleTester.run("ES2022", plugin.rules.exports, es2022Tests);

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -797,6 +797,11 @@ const es2022Tests = {
     // Simple cases.
     `export { a as "a b", z } from "x"`,
     `export { a, z as "z z" } from "x"`,
+
+    // Quoted names are sorted by their string value, like other exported
+    // names.
+    `export { yuku, yukuTs as "yuku-ts" }; var yuku, yukuTs;`,
+    `export { oxc, oxcTs as "oxc-ts" }; var oxc, oxcTs;`,
   ],
 
   invalid: [
@@ -814,6 +819,24 @@ const es2022Tests = {
       code: `export { z, "a-a" } from "x"`,
       output: (actual) => {
         expect(actual).toMatchInlineSnapshot(`export { "a-a",z } from "x"`);
+      },
+      errors: 1,
+    },
+
+    // Quoted names are sorted by their string value.
+    {
+      code: `export { yukuTs as "yuku-ts", yuku }; var yuku, yukuTs;`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { yuku,yukuTs as "yuku-ts" }; var yuku, yukuTs;`,
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `export { "b-b", "a-a" } from "x"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`export { "a-a","b-b" } from "x"`);
       },
       errors: 1,
     },

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -1621,6 +1621,59 @@ const baseTests = (expect) => ({
   ],
 });
 
+// ES2022 arbitrary module namespace names (quoted names). These are tested
+// separately because they require `ecmaVersion: 2022`, and because the
+// TypeScript parser version used in these tests does not support them.
+const es2022Tests = {
+  valid: [
+    // Simple cases.
+    `import { "a-b" as c, d } from "x"`,
+  ],
+
+  invalid: [
+    // Quoted names are sorted by their string value.
+    {
+      code: `import { d, "a-b" as c } from "x"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { "a-b" as c,d } from "x"`,
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `import { "b b" as b, "a a" as a } from "x"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { "a a" as a,"b b" as b } from "x"`,
+        );
+      },
+      errors: 1,
+    },
+    {
+      code: `import { c, "a-b" as b, a } from "x"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { a,"a-b" as b, c } from "x"`,
+        );
+      },
+      errors: 1,
+    },
+
+    // The string value is used for sorting (not the quote characters), so the
+    // choice of quote character doesn’t affect the order.
+    {
+      code: `import { "a-b" as y, 'a-a' as x } from "x"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { 'a-a' as x,"a-b" as y } from "x"`,
+        );
+      },
+      errors: 1,
+    },
+  ],
+};
+
 const flowTests = {
   valid: [
     // Simple cases.
@@ -2155,6 +2208,10 @@ const typescriptRuleTester = new RuleTester({
   parserOptions: { sourceType: "module" },
 });
 
+const es2022RuleTester = new RuleTester({
+  parserOptions: { ecmaVersion: 2022, sourceType: "module" },
+});
+
 javascriptRuleTester.run("JavaScript", plugin.rules.imports, baseTests(expect));
 
 flowRuleTester.run("Flow", plugin.rules.imports, baseTests(expect2));
@@ -2172,3 +2229,5 @@ typescriptRuleTester.run(
   plugin.rules.imports,
   typescriptTests,
 );
+
+es2022RuleTester.run("ES2022", plugin.rules.imports, es2022Tests);


### PR DESCRIPTION
ES2022 allows string literals as module export names ("arbitrary module namespace names"):

```js
export { yukuTs as "yuku-ts" };
import { "a-b" as c } from "a";
```

Two bugs with these, fixed in separate commits:

**Autofix produced invalid code (#215).** When the last specifier ended with a quoted name (and had no trailing comma), the token walk that finds the end of the last specifier in `getSpecifierItems` only accepted identifier and keyword tokens, so the string token was cut out of the specifier:

```js
// Before autofix:
export { z, a as "a b" } from "x"
// After autofix:
export { a as, "a b"z } from "x"
```

It was even worse for a quoted name without `as`: `export { z, "a-a" } from "x"` became `export { ,"a-a"z } from "x"`. Fixed by also accepting string tokens.

**Inconsistent sort order (#216).** Specifiers were sorted by `(imported || exported).name`, which is `undefined` for quoted names (they are `Literal` nodes, not `Identifier`s). All quoted names compared as the string `"undefined"`, so where they ended up relative to unquoted names depended on what the other names happened to be:

```js
export { yukuTs as "yuku-ts", yuku }; // was considered sorted
export { oxc, oxcTs as "oxc-ts" }; // was also considered sorted
```

Fixed by sorting `Literal` names by their string value (`a-b`) rather than their raw source text (`"a-b"`), so quoted names sort among unquoted names by the actual name, and the choice of quote character doesn't affect the order. With this, both examples above consistently autofix to putting the unquoted name first (sorted by the name to the right of `as`, as documented in the readme).

Notes:

- Imports are only affected by the second bug: in imports a quoted name can only appear to the left of `as`, so an import specifier can never _end_ with a string token.
- The new tests are in a separate `es2022Tests` group run with `ecmaVersion: 2022`, because the base tests use `ecmaVersion: 2020` (espree rejects quoted names there) and the `@typescript-eslint/parser` version used in the tests does not support arbitrary module namespace names at all.

Fixes #215.
Fixes #216.
