### PR TITLE
Add opt-in caseSensitive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ For a long time, this plugin used to have no options, which helped keeping it si
 
 While the human alphabetical sorting and comment handling seems to work for a lot of people, grouping of imports is more difficult. Projects differ too much to have a one-size-fits-all grouping.
 
-I’ve decided to have this single option but nothing more. Here are some things you can’t configure:
+I’ve decided to have these two options but nothing more. Here are some things you can’t configure:
 
-- The sorting within each group. It is what it is. See [Sorting].
+- The sorting within each group (apart from case sensitivity). It is what it is. See [Sorting].
 - Sorting of [side effect imports][safe] (they always stay in the original order).
 
 If you want more options, I recommend using the [import/order] rule (from [eslint-plugin-import]) instead. It has plenty of options, and the maintainers seem interested in expanding the feature where it makes sense.
@@ -233,6 +233,15 @@ function compare(a, b) {
 ```
 
 In other words, the imports/exports within groups are sorted alphabetically, case-insensitively and treating numbers like a human would, falling back to good old character code sorting in case of ties. See [Intl.Collator] for more information. Note: `Intl.Collator` sorts punctuation in _some_ defined order. I have no idea what order punctuation sorts in, and I don’t care. There’s no ordered “alphabet” for punctuation that I know of.
+
+If you prefer character code sorting, both rules have a `caseSensitive` option (default: `false`):
+
+```js
+"simple-import-sort/imports": ["error", { caseSensitive: true }],
+"simple-import-sort/exports": ["error", { caseSensitive: true }],
+```
+
+With `caseSensitive: true`, all uppercase letters come before all lowercase ones (`CONSTANTS`, then `Classes`, then `camelCase`). Runs of digits are still treated like a human would (`x2` comes before `x10`), and full character code sorting is still used as the fallback in case of ties. The option affects every name comparison: the `from` strings, imported/exported names and local names.
 
 There’s one addition to the alphabetical rule: Directory structure. Relative imports/exports of files higher up in the directory structure come before closer ones – `"../../utils"` comes before `"../utils"`, which comes before `"."`. (In short, `.` and `/` sort before any other (non-whitespace, non-control) character. `".."` and similar sort like `"../,"` (to avoid the “shorter prefix comes first” sorting concept).)
 
@@ -356,12 +365,13 @@ Workaround to make the next section to appear in the table of contents.
 
 ## Custom grouping
 
-There is **one** option (see [Not for everyone]) called `groups` that is useful for a bunch of different use cases.
+Besides `caseSensitive` (see [Sorting]), there is **one** more option (see [Not for everyone]) called `groups` that is useful for a bunch of different use cases. It exists for the `imports` rule only.
 
 `groups` is an array of arrays of strings:
 
 ```ts
 type Options = {
+  caseSensitive: boolean;
   groups: Array<Array<string>>;
 };
 ```

--- a/src/exports.js
+++ b/src/exports.js
@@ -6,7 +6,17 @@ module.exports = {
   meta: {
     type: "layout",
     fixable: "code",
-    schema: [],
+    schema: [
+      {
+        type: "object",
+        properties: {
+          caseSensitive: {
+            type: "boolean",
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
     docs: {
       url: "https://github.com/lydell/eslint-plugin-simple-import-sort#sort-order",
       description: "Automatically sort exports.",
@@ -16,6 +26,8 @@ module.exports = {
     },
   },
   create: (context) => {
+    const { caseSensitive = false } = context.options[0] || {};
+
     const parents = new Set();
 
     const addParent = (node) => {
@@ -27,7 +39,7 @@ module.exports = {
     return {
       ExportNamedDeclaration: (node) => {
         if (node.source == null && node.declaration == null) {
-          maybeReportExportSpecifierSorting(node, context);
+          maybeReportExportSpecifierSorting(node, context, caseSensitive);
         } else {
           addParent(node);
         }
@@ -41,7 +53,7 @@ module.exports = {
           for (const chunk of shared.extractChunks(parent, (node, lastNode) =>
             isPartOfChunk(node, lastNode, sourceCode),
           )) {
-            maybeReportChunkSorting(chunk, context);
+            maybeReportChunkSorting(chunk, context, caseSensitive);
           }
         }
         parents.clear();
@@ -50,26 +62,28 @@ module.exports = {
   },
 };
 
-function maybeReportChunkSorting(chunk, context) {
+function maybeReportChunkSorting(chunk, context, caseSensitive) {
   const sourceCode = shared.getSourceCode(context);
   const items = shared.getImportExportItems(
     chunk,
     sourceCode,
     () => 1, // getStyle
     getSpecifiers,
+    caseSensitive,
   );
-  const sortedItems = [[shared.sortImportExportItems(items)]];
+  const sortedItems = [[shared.sortImportExportItems(items, caseSensitive)]];
   const sorted = shared.printSortedItems(sortedItems, items, sourceCode);
   const { start } = items[0];
   const { end } = items[items.length - 1];
   shared.maybeReportSorting(context, sorted, start, end);
 }
 
-function maybeReportExportSpecifierSorting(node, context) {
+function maybeReportExportSpecifierSorting(node, context, caseSensitive) {
   const sorted = shared.printWithSortedSpecifiers(
     node,
     shared.getSourceCode(context),
     getSpecifiers,
+    caseSensitive,
   );
   const [start, end] = node.range;
   shared.maybeReportSorting(context, sorted, start, end);

--- a/src/imports.js
+++ b/src/imports.js
@@ -26,6 +26,9 @@ module.exports = {
       {
         type: "object",
         properties: {
+          caseSensitive: {
+            type: "boolean",
+          },
           groups: {
             type: "array",
             items: {
@@ -48,7 +51,8 @@ module.exports = {
     },
   },
   create: (context) => {
-    const { groups: rawGroups = defaultGroups } = context.options[0] || {};
+    const { caseSensitive = false, groups: rawGroups = defaultGroups } =
+      context.options[0] || {};
 
     const outerGroups = rawGroups.map((groups) =>
       groups.map((item) => RegExp(item, "u")),
@@ -66,7 +70,7 @@ module.exports = {
           for (const chunk of shared.extractChunks(parent, (node) =>
             isImport(node) ? "PartOfChunk" : "NotPartOfChunk",
           )) {
-            maybeReportChunkSorting(chunk, context, outerGroups);
+            maybeReportChunkSorting(chunk, context, outerGroups, caseSensitive);
           }
         }
         parents.clear();
@@ -75,22 +79,23 @@ module.exports = {
   },
 };
 
-function maybeReportChunkSorting(chunk, context, outerGroups) {
+function maybeReportChunkSorting(chunk, context, outerGroups, caseSensitive) {
   const sourceCode = shared.getSourceCode(context);
   const items = shared.getImportExportItems(
     chunk,
     sourceCode,
     getStyle,
     getSpecifiers,
+    caseSensitive,
   );
-  const sortedItems = makeSortedItems(items, outerGroups);
+  const sortedItems = makeSortedItems(items, outerGroups, caseSensitive);
   const sorted = shared.printSortedItems(sortedItems, items, sourceCode);
   const { start } = items[0];
   const { end } = items[items.length - 1];
   shared.maybeReportSorting(context, sorted, start, end);
 }
 
-function makeSortedItems(items, outerGroups) {
+function makeSortedItems(items, outerGroups, caseSensitive) {
   const itemGroups = outerGroups.map((groups) =>
     groups.map((regex) => ({ regex, items: [] })),
   );
@@ -128,7 +133,9 @@ function makeSortedItems(items, outerGroups) {
     .map((groups) => groups.filter((group) => group.items.length > 0))
     .filter((groups) => groups.length > 0)
     .map((groups) =>
-      groups.map((group) => shared.sortImportExportItems(group.items)),
+      groups.map((group) =>
+        shared.sortImportExportItems(group.items, caseSensitive),
+      ),
     );
 }
 

--- a/src/shared.js
+++ b/src/shared.js
@@ -105,6 +105,7 @@ function getImportExportItems(
   sourceCode,
   getStyle,
   getSpecifiers,
+  caseSensitive,
 ) {
   const chunk = handleLastSemicolon(passedChunk, sourceCode);
   return chunk.map((node, nodeIndex) => {
@@ -157,7 +158,12 @@ function getImportExportItems(
     const code =
       indentation +
       before +
-      printWithSortedSpecifiers(node, sourceCode, getSpecifiers) +
+      printWithSortedSpecifiers(
+        node,
+        sourceCode,
+        getSpecifiers,
+        caseSensitive,
+      ) +
       after +
       trailingSpaces;
 
@@ -228,7 +234,12 @@ function handleLastSemicolon(chunk, sourceCode) {
   return chunk.slice(0, lastIndex).concat(newLastNode);
 }
 
-function printWithSortedSpecifiers(node, sourceCode, getSpecifiers) {
+function printWithSortedSpecifiers(
+  node,
+  sourceCode,
+  getSpecifiers,
+  caseSensitive,
+) {
   const allTokens = getAllTokens(node, sourceCode);
   const openBraceIndex = allTokens.findIndex((token) =>
     isPunctuator(token, "{"),
@@ -255,7 +266,7 @@ function printWithSortedSpecifiers(node, sourceCode, getSpecifiers) {
     node: specifiers[index],
   }));
 
-  const sortedItems = sortSpecifierItems(items);
+  const sortedItems = sortSpecifierItems(items, caseSensitive);
 
   const newline = guessNewline(sourceCode);
 
@@ -711,7 +722,7 @@ function getTrailingSpaces(node, sourceCode) {
 
 const SideEffectImport = 0;
 
-function sortImportExportItems(items) {
+function sortImportExportItems(items, caseSensitive) {
   return items.slice().sort((itemA, itemB) =>
     // If both items are side effect imports, keep their original order.
     itemA.style === SideEffectImport && itemB.style === SideEffectImport
@@ -722,12 +733,16 @@ function sortImportExportItems(items) {
         : itemB.style === SideEffectImport
           ? 1
           : // Compare the `from` part.
-            compare(itemA.source.source, itemB.source.source) ||
+            compare(itemA.source.source, itemB.source.source, caseSensitive) ||
             // The `.source` has been slightly tweaked. To stay fully deterministic,
             // also sort on the original value.
-            compare(itemA.source.originalSource, itemB.source.originalSource) ||
+            compare(
+              itemA.source.originalSource,
+              itemB.source.originalSource,
+              caseSensitive,
+            ) ||
             // Then put type imports/exports before regular ones.
-            compare(itemA.source.kind, itemB.source.kind) ||
+            compare(itemA.source.kind, itemB.source.kind, caseSensitive) ||
             // Then sort by style.
             // imports: namespace < default (maybe with named) < named-only
             // exports: no styles.
@@ -739,7 +754,7 @@ function sortImportExportItems(items) {
   );
 }
 
-function sortSpecifierItems(items) {
+function sortSpecifierItems(items, caseSensitive) {
   return items.slice().sort(
     (itemA, itemB) =>
       // Compare by imported or exported name (external interface name).
@@ -750,6 +765,7 @@ function sortSpecifierItems(items) {
       compare(
         getSpecifierName(itemA.node.imported || itemA.node.exported),
         getSpecifierName(itemB.node.imported || itemB.node.exported),
+        caseSensitive,
       ) ||
       // Then compare by the file-local name.
       // import { a as b } from "a"
@@ -759,11 +775,13 @@ function sortSpecifierItems(items) {
       compare(
         getSpecifierName(itemA.node.local),
         getSpecifierName(itemB.node.local),
+        caseSensitive,
       ) ||
       // Then put type specifiers before regular ones.
       compare(
         getImportExportKind(itemA.node),
         getImportExportKind(itemB.node),
+        caseSensitive,
         /* v8 ignore start */
       ) ||
       // Keep the original order if the names are the same. It’s not worth
@@ -792,8 +810,51 @@ const collator = new Intl.Collator("en", {
   numeric: true,
 });
 
-function compare(a, b) {
-  return collator.compare(a, b) || (a < b ? -1 : a > b ? 1 : 0);
+function compare(a, b, caseSensitive) {
+  return (
+    (caseSensitive ? compareCaseSensitive(a, b) : collator.compare(a, b)) ||
+    (a < b ? -1 : a > b ? 1 : 0)
+  );
+}
+
+const digitRuns = /(\d+)/;
+
+// Compare by character code (all uppercase letters come before all lowercase
+// ones), except that runs of digits are still compared by their numeric value,
+// like the collator does with `numeric: true` (so `x2` comes before `x10`).
+// Ties (such as `x1` vs `x01`) are left to the fallback in `compare`.
+function compareCaseSensitive(a, b) {
+  const aParts = a.split(digitRuns);
+  const bParts = b.split(digitRuns);
+  const length = Math.max(aParts.length, bParts.length);
+  let result = 0;
+  for (let index = 0; index < length && result === 0; index++) {
+    const aPart = index < aParts.length ? aParts[index] : "";
+    const bPart = index < bParts.length ? bParts[index] : "";
+    // Odd indexes are the digit runs captured by the split. They are never
+    // empty strings, so an empty string means that the whole string has ended
+    // and can be compared as usual.
+    result =
+      index % 2 === 1 && aPart !== "" && bPart !== ""
+        ? compareDigitRuns(aPart, bPart)
+        : aPart < bPart
+          ? -1
+          : aPart > bPart
+            ? 1
+            : 0;
+  }
+  return result;
+}
+
+function compareDigitRuns(a, b) {
+  const aDigits = a.replace(/^0+/, "");
+  const bDigits = b.replace(/^0+/, "");
+  return (
+    // More digits (after removing leading zeros) means a bigger number.
+    aDigits.length - bDigits.length ||
+    // With equally many digits, compare them in order.
+    (aDigits < bDigits ? -1 : aDigits > bDigits ? 1 : 0)
+  );
 }
 
 function isIdentifier(node) {

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -64,6 +64,19 @@ const baseTests = (expect) => ({
           |// export {b} from "b";
           |export {c} from "c";
     `,
+
+    // `caseSensitive: true` – already sorted by character code.
+    {
+      code: `export { B, a }; var B, a;`,
+      options: [{ caseSensitive: true }],
+    },
+    {
+      code: input`
+          |export * from "./Button";
+          |export * from "./api";
+      `,
+      options: [{ caseSensitive: true }],
+    },
   ],
 
   invalid: [
@@ -145,6 +158,46 @@ const baseTests = (expect) => ({
         expect(actual).toMatchInlineSnapshot(
           `export { a,b, a as b2, a as c, d,  }; var d, a, b;`,
         );
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – specifiers are sorted by character code.
+    {
+      options: [{ caseSensitive: true }],
+      code: `export { iconNames, Bubble, Text, Icon } from "wrapped"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { Bubble, Icon,Text, iconNames } from "wrapped"`,
+        );
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – the exported (external) name is what counts.
+    {
+      options: [{ caseSensitive: true }],
+      code: `export { a as b, a as C } from "renames"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `export { a as C,a as b } from "renames"`,
+        );
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – the `from` strings are sorted by character code.
+    {
+      options: [{ caseSensitive: true }],
+      code: input`
+          |export * from "./api";
+          |export * from "./Button";
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |export * from "./Button";
+          |export * from "./api";
+        `);
       },
       errors: 1,
     },

--- a/test/imports.test.js
+++ b/test/imports.test.js
@@ -74,6 +74,32 @@ const baseTests = (expect) => ({
           |import b from "b";    
           |import c from "c";  /* comment */  
     `,
+
+    // `caseSensitive: true` – already sorted by character code.
+    {
+      code: `import { B, a } from "a"`,
+      options: [{ caseSensitive: true }],
+    },
+    {
+      code: `import { x, x1 } from "a"`,
+      options: [{ caseSensitive: true }],
+    },
+    {
+      code: input`
+          |import b from "./Button"
+          |import a from "./api"
+      `,
+      options: [{ caseSensitive: true }],
+    },
+
+    // `caseSensitive: true` – side effect imports keep their original order.
+    {
+      code: input`
+          |import "b"
+          |import "A"
+      `,
+      options: [{ caseSensitive: true }],
+    },
   ],
 
   invalid: [
@@ -1618,6 +1644,77 @@ const baseTests = (expect) => ({
       },
       errors: 1,
     },
+
+    // `caseSensitive` – specifiers are sorted by character code.
+    {
+      options: [{ caseSensitive: true }],
+      code: `import { iconNames, Bubble, Text, Icon } from "wrapped"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { Bubble, Icon,Text, iconNames } from "wrapped"`,
+        );
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – for equal imported names, the local name decides.
+    {
+      options: [{ caseSensitive: true }],
+      code: `import { a as b, a as C } from "renames"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { a as C,a as b } from "renames"`,
+        );
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – runs of digits are still compared numerically.
+    {
+      options: [{ caseSensitive: true }],
+      code: `import { x1, x01, x100, x24, x23, x2, x } from "numeric"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { x,x01, x1, x2, x23, x24, x100 } from "numeric"`,
+        );
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – the `from` strings are sorted by character code.
+    {
+      options: [{ caseSensitive: true }],
+      code: input`
+          |import y from "./api"
+          |import x from "./Button"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import x from "./Button"
+          |import y from "./api"
+        `);
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – works together with `groups`.
+    {
+      options: [{ caseSensitive: true, groups: [["^\\w"], ["^\\."]] }],
+      code: input`
+          |import b from "component"
+          |import c from "./local"
+          |import a from "Component"
+      `,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(`
+          |import a from "Component"
+          |import b from "component"
+          |
+          |import c from "./local"
+        `);
+      },
+      errors: 1,
+    },
   ],
 });
 
@@ -1998,6 +2095,18 @@ const typescriptTests = {
           |  return names.map(n => o[n]);
           |}
         `);
+      },
+      errors: 1,
+    },
+
+    // `caseSensitive` – type specifiers are sorted by character code.
+    {
+      options: [{ caseSensitive: true }],
+      code: `import { type b, type A, C } from "wrapped"`,
+      output: (actual) => {
+        expect(actual).toMatchInlineSnapshot(
+          `import { type A, C,type b } from "wrapped"`,
+        );
       },
       errors: 1,
     },


### PR DESCRIPTION
I'll start with the awkward part: I've read [Not for everyone](https://github.com/lydell/eslint-plugin-simple-import-sort#not-for-everyone), including the line this PR collides with head-on - the sorting within each group, "It is what it is." So this proposal is, by the README's own words, pre-answered. I'm opening it once anyway, with my best case, and my only ask is a read to the end before deciding. If the answer is still no after that, that's genuinely ok - the README says so.

Some context: I've used simple-import-sort for many years, across many projects, and I'm a genuinely happy user - it's the rare tool you set up once and then completely forget about, which I know is exactly the design goal. In all those years there has been exactly one thing that bugs me, every single time I read an import line, and this is it.

For me, import sorting has one job: making the top of every file scannable in a predictable way. Groups do the heavy lifting there - they cluster imports by how external the referenced module is. The primary value was never the alphabet itself; it's that related things reliably sit next to each other.

Case-insensitive sorting quietly breaks that principle one level down, inside the braces. It effectively declares "capitalization doesn't matter" - but in JavaScript and TypeScript, capitalization is one of the strongest conventions we have. PascalCase names are components, classes, and types; camelCase names are values and functions. Casing isn't noise to be normalized away; it encodes what kind of thing I'm importing.

Sorted case-sensitively, a specifier list clusters naturally by kind:

```js
import { Alert, Menu, Table, debounce, formatDate, request } from "ui-kit";
```

reads as two clean blocks: three components, then three utilities. Sorted case-insensitively, the kinds interleave all the way through:

```js
import { Alert, debounce, formatDate, Menu, request, Table } from "ui-kit";
```

and the result feels arbitrarily shuffled even though it is technically ordered. The longer the import, the worse the effect.

I fully accept this is subjective - #7 showed reasonable people land on both sides. But the plugin itself already agrees that specifiers of different kinds should cluster: it sorts `type` specifiers before value specifiers within the same braces. Case-sensitive sorting is the same instinct applied to the casing convention. It is also the default in ESLint core's [`sort-imports`](https://eslint.org/docs/latest/rules/sort-imports#ignorecase) (`ignoreCase: false`) and in eslint-plugin-import's [`alphabetize`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md#alphabetize) (`caseInsensitive: false`) once alphabetizing is enabled - and it was this plugin's own behavior before v4. In fact, #7 captures both sides in a single thread: your first take there was "I actually prefer the uppercase ones (CONSTANTS, Classes, Types) coming first", and the default only changed after you tried the alternative for real. So the order behind this option is not an exotic taste; it is the one the plugin shipped with, and the one part of its user base never stopped preferring.

To be clear: this PR does not relitigate the default. Case-insensitive clearly matches how many people think, and existing users see zero change - the option defaults to `false`, and every existing test passes untouched. What it adds is an opt-in toggle:

```js
"simple-import-sort/imports": ["error", { caseSensitive: true }],
"simple-import-sort/exports": ["error", { caseSensitive: true }],
```

The option applies to every name comparison the plugin makes: specifier names inside braces (in both rules - `exports` gains its first option), local names, and the `from` strings, so statement order follows the same convention (`./Button` before `./api`). Number handling is untouched: runs of digits still compare numerically (`x2` before `x10`) and ties still fall back to char-code order, exactly like today. Only the case behavior changes.

The diff is small in a satisfying way: the case-sensitive ordering already exists in the plugin - it's the char-code tiebreak inside `compare()`, which today decides the order of every collator-equal pair. With the option on, that ordering is essentially promoted to primary, minus the digit runs. No new ordering concept. A custom comparator is unavoidable in any case, since `Intl.Collator` cannot express char-code order (`caseFirst: "upper"` only affects same-letter ties). The PR keeps the repo's standards: zero dependencies, schema validation for both rules, README docs, new tests across all parsers, existing tests untouched, and coverage stays at 100%.

The README justifies the one existing option with "Projects differ too much to have a one-size-fits-all grouping." I believe case handling has quietly met the same bar: tooling defaults are split down the middle, and #7, #64, #80 show the case-sensitive camp keeps arriving independently, year after year. There is no one-size-fits-all sort order either - only two established conventions.

Finally, on the options-free philosophy: I understand and respect it - it's part of why the plugin is so pleasant to use, and I wouldn't be proposing this if I saw another way. Practically, there are two outcomes: one boolean that lets both camps keep sharing one excellent plugin, or people like me maintaining patches - or outright forks duplicating 99% of the code - to change a few comparisons. I've been running such a patch in production - it works fine, but nobody should have to maintain one for this, least of all me. That's why this arrives as a complete PR rather than a feature request.
